### PR TITLE
ci: Require lint and unit tests to pass before running integration tests

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -24,6 +24,8 @@ jobs:
 
   tests:
     name: Run Tests
+    needs:
+      - lint
     uses: ./.github/workflows/tests.yaml
     secrets:
       charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,8 @@ jobs:
   integration-test-microk8s:
     name: Integration tests (microk8s)
     runs-on: ubuntu-22.04
+    needs:
+      - unit-test
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
In order to save resources, the `tests` workflow should only run if lint check succeeded. Within the `tests` workflow, integration should only run if unit tests passed.