### PR TITLE
Fix `on_push.yaml` workflow

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
     secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:


### PR DESCRIPTION
The `on_push.yaml` workflow is failing due to invalid secret name. It needs to be uppercase as defined in settings.