### PR TITLE
Remove secret reference for running tests on push

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -17,8 +17,6 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:


### PR DESCRIPTION
This PR fixes the error returned on push:
```
The workflow is not valid. .github/workflows/on_push.yaml (Line: 21, Col: 31): Invalid secret, CHARMCRAFT_CREDENTIALS is not defined in the referenced workflow.
```

`CHARMCRAFT_CREDENTIALS` is not needed to run tests.