### PR TITLE
Add jinja template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Canonical Ltd.
+   Copyright 2023 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 type: charm

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: hydra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # Testing tools configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ops==1.5.3
 lightkube
 lightkube-models
+jinja2
 jsonschema

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/templates/hydra.yaml.j2
+++ b/templates/hydra.yaml.j2
@@ -1,0 +1,14 @@
+dsn: postgres://{{ db_info.get('username') }}:{{ db_info.get('password') }}@{{ db_info.get('endpoints') }}/{{ db_info.get('database_name') }}
+log:
+  level: trace
+secrets:
+  cookie:
+  - my-cookie-secret
+  system:
+  - my-system-secret
+urls:
+  consent: {{ consent_url }}
+  error: {{ error_url }}
+  login: {{ login_url }}
+  self:
+    issuer: http://localhost:4444/

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import logging

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import ops.testing

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import pytest

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import json

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -136,15 +136,16 @@ def test_update_container_config(harness, mocked_kubernetes_service_patcher, moc
             "system": ["my-system-secret"],
         },
         "urls": {
-            "consent": "http://localhost:3000/consent",
-            "login": "http://localhost:3000/login",
+            "consent": "http://localhost:4455/consent",
+            "error": "http://localhost:4455/error",
+            "login": "http://localhost:4455/login",
             "self": {
                 "issuer": "http://localhost:4444/",
             },
         },
     }
 
-    assert harness.charm._config == yaml.dump(expected_config)
+    assert yaml.safe_load(harness.charm._render_conf_file()) == expected_config
 
 
 @pytest.mark.parametrize("api_type,port", [("admin", "4445"), ("public", "4444")])

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]


### PR DESCRIPTION
- Use jinja template to generate the hydra config file. This will help to make the config more readable for future updates.
- Update copyright year