### PR TITLE
Delete clients when oauth relation is broken

### DIFF
--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -612,8 +612,7 @@ class OAuthProvider(Object):
         return f"client_secret_{relation.id}"
 
     def _on_relation_departed(self, event: RelationDepartedEvent) -> None:
-        secret = self.model.get_secret(label=self._get_secret_label(event.relation))
-        secret.remove_all_revisions()
+        self._delete_juju_secret(event.relation)
         self.on.client_deleted.emit(event.relation.id)
 
     def _create_juju_secret(self, client_secret: str, relation: Relation) -> Secret:
@@ -622,6 +621,10 @@ class OAuthProvider(Object):
         juju_secret = self.model.app.add_secret(secret, label=self._get_secret_label(relation))
         juju_secret.grant(relation)
         return juju_secret
+
+    def _delete_juju_secret(self, relation: Relation) -> None:
+        secret = self.model.get_secret(label=self._get_secret_label(relation))
+        secret.remove_all_revisions()
 
     def set_provider_info_in_relation_data(
         self,

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,3 +29,7 @@ provides:
       Provides API endpoints to a related application
   oauth:
     interface: oauth
+
+peers:
+  hydra:
+    interface: hydra_peers

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,14 @@ from ops.charm import (
     WorkloadEvent,
 )
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus, Relation
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    ModelError,
+    Relation,
+    WaitingStatus,
+)
 from ops.pebble import ChangeError, ExecError, Layer
 
 from hydra_cli import HydraCLI

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,9 +6,10 @@
 
 """A Juju charm for Ory Hydra."""
 
+import json
 import logging
 from os.path import join
-from typing import Any
+from typing import Any, Dict
 
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseCreatedEvent,
@@ -456,6 +457,7 @@ class HydraCharm(CharmBase):
         client = self._get_oauth_relation_peer_data(event.relation_id)
         if not client:
             logger.error("No client found in peer data")
+            return
 
         try:
             self._hydra_cli.delete_client(client["client_id"])

--- a/src/charm.py
+++ b/src/charm.py
@@ -212,11 +212,11 @@ class HydraCharm(CharmBase):
         return self.model.get_relation(PEER)
 
     def _set_peer_data(self, key: str, data: Dict) -> None:
-        """Put information into the peer data bucket instead of `StoredState`."""
+        """Put information into the peer data bucket."""
         self._peers.data[self.app][key] = json.dumps(data)
 
     def _get_peer_data(self, key: str) -> Dict:
-        """Retrieve information from the peer data bucket instead of `StoredState`."""
+        """Retrieve information from the peer data bucket."""
         if not self._peers:
             return {}
         data = self._peers.data[self.app].get(key, "")

--- a/src/charm.py
+++ b/src/charm.py
@@ -419,7 +419,6 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
-        # TODO: If this fails emit an event for reconciliation
         self._set_oauth_relation_peer_data(event.relation_id, dict(client_id=client["client_id"]))
         self.oauth.set_client_credentials_in_relation_data(
             event.relation_id, client["client_id"], client["client_secret"]
@@ -459,7 +458,6 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
-        # TODO: If this fails emit an event for reconciliation
         client = self._get_oauth_relation_peer_data(event.relation_id)
         if not client:
             logger.error("No client found in peer data")
@@ -473,7 +471,6 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
-        # TODO: If this fails emit an event for reconciliation
         self._pop_oauth_relation_peer_data(event.relation_id)
 
     def _update_endpoint_info(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -399,6 +399,12 @@ class HydraCharm(CharmBase):
             return
 
         if not self._hydra_service_is_running:
+            self.unit.status = WaitingStatus("Waiting for Hydra service")
+            event.defer()
+            return
+
+        if not self._peers:
+            self.unit.status = WaitingStatus("Waiting for peer relation")
             event.defer()
             return
 
@@ -424,6 +430,7 @@ class HydraCharm(CharmBase):
             return
 
         if not self._hydra_service_is_running:
+            self.unit.status = WaitingStatus("Waiting for Hydra service")
             event.defer()
             return
 
@@ -443,6 +450,12 @@ class HydraCharm(CharmBase):
             return
 
         if not self._hydra_service_is_running:
+            self.unit.status = WaitingStatus("Waiting for Hydra service")
+            event.defer()
+            return
+
+        if not self._peers:
+            self.unit.status = WaitingStatus("Waiting for peer relation")
             event.defer()
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -234,11 +234,11 @@ class HydraCharm(CharmBase):
         key = self._oauth_relation_peer_data_key(relation_id)
         self._set_peer_data(key, data)
 
-    def _get_oauth_relation_peer_data(self, relation_id: int) -> None:
+    def _get_oauth_relation_peer_data(self, relation_id: int) -> Dict:
         key = self._oauth_relation_peer_data_key(relation_id)
         return self._get_peer_data(key)
 
-    def _pop_oauth_relation_peer_data(self, relation_id: int) -> None:
+    def _pop_oauth_relation_peer_data(self, relation_id: int) -> Dict:
         key = self._oauth_relation_peer_data_key(relation_id)
         return self._pop_peer_data(key)
 
@@ -416,6 +416,7 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
+        # TODO: If this fails emit an event for reconciliation
         self._set_oauth_relation_peer_data(event.relation_id, dict(client_id=client["client_id"]))
         self.oauth.set_client_credentials_in_relation_data(
             event.relation_id, client["client_id"], client["client_secret"]
@@ -454,6 +455,7 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
+        # TODO: If this fails emit an event for reconciliation
         client = self._get_oauth_relation_peer_data(event.relation_id)
         if not client:
             logger.error("No client found in peer data")
@@ -470,6 +472,7 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
+        # TODO: If this fails emit an event for reconciliation
         self._pop_oauth_relation_peer_data(event.relation_id)
 
     def _update_endpoint_info(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -233,7 +233,7 @@ class HydraCharm(CharmBase):
         return json.loads(data) if data else {}
 
     def _pop_peer_data(self, key: str) -> Dict:
-        """Retrieve information from the peer data bucket."""
+        """Retrieve and remove information from the peer data bucket."""
         if not (peers := self._peers):
             return {}
         data = peers.data[self.app].pop(key, "")

--- a/src/hydra_cli.py
+++ b/src/hydra_cli.py
@@ -14,7 +14,6 @@ from ops.model import Container
 logger = logging.getLogger(__name__)
 
 
-
 class HydraCLI:
     """Helper object for running hydra CLI commands."""
 

--- a/src/hydra_cli.py
+++ b/src/hydra_cli.py
@@ -33,9 +33,9 @@ class HydraCLI:
         ]
 
         if client_config.scope:
-            for s in client_config.scope.split(" "):
+            for scope in client_config.scope.split(" "):
                 flags.append("--scope")
-                flags.append(s)
+                flags.append(scope)
         if client_config.redirect_uri:
             flags.append("--redirect-uri")
             flags.append(client_config.redirect_uri)

--- a/src/hydra_cli.py
+++ b/src/hydra_cli.py
@@ -14,6 +14,7 @@ from ops.model import Container
 logger = logging.getLogger(__name__)
 
 
+
 class HydraCLI:
     """Helper object for running hydra CLI commands."""
 
@@ -78,12 +79,12 @@ class HydraCLI:
         return json.loads(stdout)
 
     def delete_client(self, client_id: str) -> Dict:
-        """Delete one or more oauth2 client."""
+        """Delete an oauth2 client."""
         cmd = self._client_cmd_prefix("delete")
         cmd.append(client_id)
 
         stdout, _ = self._run_cmd(cmd)
-        logger.info(f"Successfully deleted clients: {stdout}")
+        logger.info(f"Successfully deleted client: {stdout}")
         return json.loads(stdout)
 
     def _run_cmd(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,7 +17,8 @@ def harness(mocked_kubernetes_service_patcher: MagicMock) -> Harness:
     harness.set_model_name("testing")
     harness.set_leader(True)
     harness.begin()
-    return harness
+    yield harness
+    harness.cleanup()
 
 
 @pytest.fixture()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 from typing import Dict, Generator
-from unittest.mock import MagicMock
 
 import pytest
 from ops.testing import Harness
@@ -12,7 +11,7 @@ from charm import HydraCharm
 
 
 @pytest.fixture()
-def harness(mocked_kubernetes_service_patcher: MagicMock) -> Harness:
+def harness(mocked_kubernetes_service_patcher: Generator) -> Generator[Harness, None, None]:
     harness = Harness(HydraCharm)
     harness.set_model_name("testing")
     harness.set_leader(True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,7 +54,7 @@ def setup_oauth_relation(harness: Harness) -> Tuple[int, str]:
     return relation_id, app_name
 
 
-def setup_peer_relation(harness):
+def setup_peer_relation(harness: Harness) -> Tuple[int, str]:
     app_name = "hydra"
     relation_id = harness.add_relation("hydra", app_name)
     return relation_id, app_name

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -453,7 +453,6 @@ def test_client_created_event_emitted_without_peers(
     mocked_hydra_is_running: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    client_credentials = mocked_create_client.return_value
     harness.charm.on.hydra_pebble_ready.emit(CONTAINER_NAME)
 
     relation_id, _ = setup_oauth_relation(harness)
@@ -461,6 +460,7 @@ def test_client_created_event_emitted_without_peers(
     harness.charm.oauth.on.client_created.emit(relation_id=relation_id, **CLIENT_CONFIG)
 
     assert not mocked_set_client_credentials.called
+
 
 def test_client_created_event_emitted_cannot_connect(
     harness: Harness, mocked_create_client: MagicMock
@@ -593,7 +593,6 @@ def test_client_deleted_event_emitted_without_peers(
     mocked_delete_client: MagicMock,
     mocked_hydra_is_running: MagicMock,
 ) -> None:
-    client_id = "client_id"
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.hydra_pebble_ready.emit(CONTAINER_NAME)
 


### PR DESCRIPTION
Add peer relation that will be used for deleting clients when the `oauth` relation is broken