### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -25,20 +25,3 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-
-  publish-lib:
-    name: Publish library
-    needs: tests
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --channel latest/stable --classic
-
-      - name: Publish libs
-        env:
-          CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-        run: |
-          charmcraft publish-lib charms.hydra.v0.hydra_endpoints

--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -6,6 +6,8 @@ jobs:
   update-charm-libs:
     name: Update Charm Libraries
     uses: ./.github/workflows/update_libs.yaml
+    secrets:
+      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
 
   update-deps:
     name: Update Dependencies
@@ -14,5 +16,3 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/publish-lib.yaml
+++ b/.github/workflows/publish-lib.yaml
@@ -1,0 +1,26 @@
+# Publish hydra_endpoints library only if it has changed
+name: Publish library
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "./lib/charms/hydra/v0/hydra_endpoints.py"
+
+jobs:
+  publish-lib:
+    name: Publish library
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --channel latest/stable --classic
+
+      - name: Publish libs
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+        run: |
+          charmcraft publish-lib charms.hydra.v0.hydra_endpoints


### PR DESCRIPTION
Currently, the `hydra_endpoints` lib is published everytime a change is pushed to main, even if it has not changed. This may lead to some complications with charmhub.
This PR:
- adds a new `publish-lib.yaml` workflow, so that the publish action is only run when the library has changed
- fixes uncorrect secrets usage `on_schedule.yaml`