### PR TITLE
fix potential bug of referencing relation name

### DIFF
--- a/lib/charms/hydra/v0/hydra_endpoints.py
+++ b/lib/charms/hydra/v0/hydra_endpoints.py
@@ -94,7 +94,7 @@ class HydraEndpointsProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
-        relations = self.model.relations[RELATION_NAME]
+        relations = self.model.relations[self._relation_name]
         for relation in relations:
             relation.data[self._charm.app].update(
                 {


### PR DESCRIPTION
I realise that this could be the bad platform to request a change for a charm library. Let me know and I'll close this PR.

Please check if this is potentially a bug in the hydra_endpoints library. if we insist on using the relation name in the constant, then it's likely a bad idea to make it an argument for the constructor.