### PR TITLE
Update oauth lib

### DIFF
--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,9 @@ description: |
   Charmed Ory Hydra
 summary: |
   OAuth 2.0 and OpenID Connect 1.0 Provider
+assumes:
+  - juju >= 3.0.2
+  - k8s-api
 containers:
   hydra:
     resource: oci-image

--- a/tests/unit/test_oauth_requirer.py
+++ b/tests/unit/test_oauth_requirer.py
@@ -139,7 +139,15 @@ def test_get_provider_info_when_data_available(harness: Harness, provider_info: 
         provider_info,
     )
 
-    assert harness.charm.oauth.get_provider_info() == provider_info
+    expected_provider_info = harness.charm.oauth.get_provider_info()
+
+    assert expected_provider_info.authorization_endpoint == provider_info["authorization_endpoint"]
+    assert expected_provider_info.introspection_endpoint == provider_info["introspection_endpoint"]
+    assert expected_provider_info.issuer_url == provider_info["issuer_url"]
+    assert expected_provider_info.jwks_endpoint == provider_info["jwks_endpoint"]
+    assert expected_provider_info.scope == provider_info["scope"]
+    assert expected_provider_info.token_endpoint == provider_info["token_endpoint"]
+    assert expected_provider_info.userinfo_endpoint == provider_info["userinfo_endpoint"]
 
 
 def test_get_client_credentials_when_data_available(harness: Harness, provider_info: Dict) -> None:
@@ -156,9 +164,10 @@ def test_get_client_credentials_when_data_available(harness: Harness, provider_i
         dict(client_id=client_id, client_secret_id=secret_id, **provider_info),
     )
 
-    assert harness.charm.oauth.get_client_credentials() == dict(
-        client_id=client_id, client_secret=client_secret
-    )
+    expected_client_details = harness.charm.oauth.get_client_credentials()
+
+    assert expected_client_details.client_id == client_id
+    assert expected_client_details.client_secret == client_secret
 
 
 def test_exception_raised_when_malformed_redirect_url(harness: Harness) -> None:


### PR DESCRIPTION
- add dataclasses for oauth provider config to not use literal strings in requirer side, as requested by Observability team
- add assumes statement in metadata as juju secrets are supported only in v3.0.2+