### PR TITLE
fix: fixed issue with log file directory

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -422,7 +422,7 @@ class HydraCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting to connect to Hydra container")
             return
         if not self._container.isdir(str(self._log_dir)):
-            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o777)
+            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o755)
 
         self._handle_status_update_config(event)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -418,11 +418,11 @@ class HydraCharm(CharmBase):
         # Necessary directory for log forwarding
         if not self._container.can_connect():
             event.defer()
-            logger.info("Cannot connect to Hydra container. Deferring event.")
             self.unit.status = WaitingStatus("Waiting to connect to Hydra container")
             return
         if not self._container.isdir(str(self._log_dir)):
-            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o755)
+            logger.info(f"Created directory {self._log_dir}")
+            self._container.make_dir(path=str(self._log_dir), make_parents=True)
 
         self._handle_status_update_config(event)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@
 import json
 import logging
 from os.path import join
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from charms.data_platform_libs.v0.data_interfaces import (
@@ -87,8 +88,8 @@ class HydraCharm(CharmBase):
         self._prometheus_scrape_relation_name = "metrics-endpoint"
         self._loki_push_api_relation_name = "logging"
         self._hydra_service_command = "hydra serve all"
-        self._log_dir = "/var/log"
-        self._log_path = f"{self._log_dir}/hydra.log"
+        self._log_dir = Path("/var/log")
+        self._log_path = self._log_dir / "hydra.log"
         self._hydra_service_params = "--config {} --dev".format(self._hydra_config_path)
 
         self._hydra_cli = HydraCLI(f"http://localhost:{HYDRA_ADMIN_PORT}", self._container)
@@ -140,7 +141,7 @@ class HydraCharm(CharmBase):
 
         self.loki_consumer = LogProxyConsumer(
             self,
-            log_files=[self._log_path],
+            log_files=[str(self._log_path)],
             relation_name=self._loki_push_api_relation_name,
             container_name=self._container_name,
         )
@@ -210,7 +211,9 @@ class HydraCharm(CharmBase):
                     "override": "replace",
                     "summary": "entrypoint of the hydra-operator image",
                     "command": '/bin/sh -c "{} {} 2>&1 | tee -a {}"'.format(
-                        self._hydra_service_command, self._hydra_service_params, self._log_path
+                        self._hydra_service_command,
+                        self._hydra_service_params,
+                        str(self._log_path),
                     ),
                     "startup": "disabled",
                 }
@@ -418,8 +421,8 @@ class HydraCharm(CharmBase):
             logger.info("Cannot connect to Hydra container. Deferring event.")
             self.unit.status = WaitingStatus("Waiting to connect to Hydra container")
             return
-        if not self._container.isdir(self._log_dir):
-            self._container.make_dir(path=self._log_dir, make_parents=True, permissions=0o777)
+        if not self._container.isdir(str(self._log_dir)):
+            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o777)
 
         self._handle_status_update_config(event)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,8 +87,8 @@ class HydraCharm(CharmBase):
         self._prometheus_scrape_relation_name = "metrics-endpoint"
         self._loki_push_api_relation_name = "logging"
         self._hydra_service_command = "hydra serve all"
-        self._log_path = "/var/log/hydra.log"
         self._log_dir = "/var/log"
+        self._log_path = f"{self._log_dir}/hydra.log"
         self._hydra_service_params = "--config {} --dev".format(self._hydra_config_path)
 
         self._hydra_cli = HydraCLI(f"http://localhost:{HYDRA_ADMIN_PORT}", self._container)

--- a/src/charm.py
+++ b/src/charm.py
@@ -421,8 +421,8 @@ class HydraCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting to connect to Hydra container")
             return
         if not self._container.isdir(str(self._log_dir)):
-            logger.info(f"Created directory {self._log_dir}")
             self._container.make_dir(path=str(self._log_dir), make_parents=True)
+            logger.info(f"Created directory {self._log_dir}")
 
         self._handle_status_update_config(event)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -180,3 +180,15 @@ def mocked_log_proxy_consumer_setup_promtail(mocker: MockerFixture) -> MagicMock
         "charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._setup_promtail", return_value=None
     )
     return mocked_setup_promtail
+
+
+@pytest.fixture()
+def mocked_isdir(mocker: MockerFixture) -> MagicMock:
+    mocked_isdir = mocker.patch("ops.Container.isdir", return_value=False)
+    return mocked_isdir
+
+
+@pytest.fixture()
+def mocked_make_dir(mocker: MockerFixture) -> MagicMock:
+    mocked_make_dir = mocker.patch("ops.Container.make_dir", return_value=None)
+    return mocked_make_dir

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -180,15 +180,3 @@ def mocked_log_proxy_consumer_setup_promtail(mocker: MockerFixture) -> MagicMock
         "charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._setup_promtail", return_value=None
     )
     return mocked_setup_promtail
-
-
-@pytest.fixture()
-def mocked_isdir(mocker: MockerFixture) -> MagicMock:
-    mocked_isdir = mocker.patch("ops.Container.isdir", return_value=False)
-    return mocked_isdir
-
-
-@pytest.fixture()
-def mocked_make_dir(mocker: MockerFixture) -> MagicMock:
-    mocked_make_dir = mocker.patch("ops.Container.make_dir", return_value=None)
-    return mocked_make_dir

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1103,11 +1103,20 @@ def test_on_pebble_ready_make_dir_called(
     harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    setup_postgres_relation(harness)
-    setup_peer_relation(harness)
     container = harness.model.unit.get_container(CONTAINER_NAME)
     harness.charm.on.hydra_pebble_ready.emit(container)
 
-    assert harness.model.unit.status == ActiveStatus()
     mocked_isdir.assert_called_once_with("/var/log")
     mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o777)
+
+
+def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(
+    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
+) -> None:
+    harness.set_can_connect(CONTAINER_NAME, False)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.hydra_pebble_ready.emit(container)
+
+    assert harness.model.unit.status == WaitingStatus("Waiting to connect to Hydra container")
+    mocked_isdir.assert_not_called
+    mocked_make_dir.assert_not_called

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1107,7 +1107,7 @@ def test_on_pebble_ready_make_dir_called(
     harness.charm.on.hydra_pebble_ready.emit(container)
 
     mocked_isdir.assert_called_once_with("/var/log")
-    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o777)
+    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o755)
 
 
 def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1097,3 +1097,17 @@ def test_on_config_changed_with_invalid_log_level(harness: Harness) -> None:
 
     assert isinstance(harness.model.unit.status, BlockedStatus)
     assert "Invalid configuration value for log_level" in harness.charm.unit.status.message
+
+
+def test_on_pebble_ready_make_dir_called(
+    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
+) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
+    setup_postgres_relation(harness)
+    setup_peer_relation(harness)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.hydra_pebble_ready.emit(container)
+
+    assert harness.model.unit.status == ActiveStatus()
+    mocked_isdir.assert_called_once_with("/var/log")
+    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o777)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1107,7 +1107,7 @@ def test_on_pebble_ready_make_dir_called(
     harness.charm.on.hydra_pebble_ready.emit(container)
 
     mocked_isdir.assert_called_once_with("/var/log")
-    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o755)
+    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True)
 
 
 def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1099,24 +1099,8 @@ def test_on_config_changed_with_invalid_log_level(harness: Harness) -> None:
     assert "Invalid configuration value for log_level" in harness.charm.unit.status.message
 
 
-def test_on_pebble_ready_make_dir_called(
-    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
-) -> None:
+def test_on_pebble_ready_make_dir_called(harness: Harness) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     container = harness.model.unit.get_container(CONTAINER_NAME)
     harness.charm.on.hydra_pebble_ready.emit(container)
-
-    mocked_isdir.assert_called_once_with("/var/log")
-    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True)
-
-
-def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(
-    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
-) -> None:
-    harness.set_can_connect(CONTAINER_NAME, False)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
-    harness.charm.on.hydra_pebble_ready.emit(container)
-
-    assert harness.model.unit.status == WaitingStatus("Waiting to connect to Hydra container")
-    mocked_isdir.assert_not_called
-    mocked_make_dir.assert_not_called
+    assert container.isdir("/var/log")


### PR DESCRIPTION
Fixed the issue of directory in log file path not being present in rock. Manually verified to work.

To test:

deploy hydra
deploy loki
integrate hydra with loki
after entering curl loki_url:3100/loki/api/v1/label/juju_unit/values command you should see the hydra unit you deployed