### PR TITLE
Store migration in peer relation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -400,7 +400,7 @@ class HydraCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for database creation")
             return
 
-        if not self._migration_is_needed():
+        if self._migration_is_needed():
             self.unit.status = WaitingStatus("Waiting for migration to run")
             return
 
@@ -459,7 +459,6 @@ class HydraCharm(CharmBase):
         self.unit.status = MaintenanceStatus(
             "Configuring container and resources for database connection"
         )
-
         logger.info("Updating Hydra config and restarting service")
         self._container.add_layer(self._container_name, self._hydra_layer, combine=True)
         self._container.push(self._hydra_config_path, self._render_conf_file(), make_dirs=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -400,6 +400,10 @@ class HydraCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for database creation")
             return
 
+        if not self._migration_is_needed():
+            self.unit.status = WaitingStatus("Waiting for migration to run")
+            return
+
         self._container.push(self._hydra_config_path, self._render_conf_file(), make_dirs=True)
         self._container.restart(self._container_name)
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -71,6 +71,7 @@ HYDRA_PUBLIC_PORT = 4444
 SUPPORTED_SCOPES = ["openid", "profile", "email", "phone"]
 PEER = "hydra"
 LOG_LEVELS = ["panic", "fatal", "error", "warn", "info", "debug", "trace"]
+DB_MIGRATION_VERSION_KEY = "migration_version"
 
 
 class HydraCharm(CharmBase):
@@ -92,7 +93,9 @@ class HydraCharm(CharmBase):
         self._log_path = self._log_dir / "hydra.log"
         self._hydra_service_params = "--config {} --dev".format(self._hydra_config_path)
 
-        self._hydra_cli = HydraCLI(f"http://localhost:{HYDRA_ADMIN_PORT}", self._container)
+        self._hydra_cli = HydraCLI(
+            f"http://localhost:{HYDRA_ADMIN_PORT}", self._container, self._hydra_config_path
+        )
 
         self.service_patcher = KubernetesServicePatch(
             self, [("hydra-admin", HYDRA_ADMIN_PORT), ("hydra-public", HYDRA_PUBLIC_PORT)]
@@ -310,15 +313,14 @@ class HydraCharm(CharmBase):
             "database_name": self._db_name,
         }
 
-    def _run_sql_migration(self, set_timeout: bool) -> None:
+    def _run_sql_migration(self, timeout: float = 60) -> bool:
         """Runs a command to create SQL schemas and apply migration plans."""
-        process = self._container.exec(
-            ["hydra", "migrate", "sql", "-e", "--config", self._hydra_config_path, "--yes"],
-            timeout=20.0 if set_timeout else None,
-        )
-
-        stdout, _ = process.wait_output()
-        logger.info(f"Executing automigration: {stdout}")
+        try:
+            self._hydra_cli.run_migration(timeout=timeout)
+        except ExecError as err:
+            logger.error(f"Exited with code {err.exit_code}. Stderr: {err.stderr}")
+            return False
+        return True
 
     def _oauth_relation_peer_data_key(self, relation_id: int) -> str:
         return f"oauth_{relation_id}"
@@ -426,15 +428,18 @@ class HydraCharm(CharmBase):
 
         self._handle_status_update_config(event)
 
+    def _migration_is_needed(self):
+        if not self._peers:
+            return
+
+        return (
+            self._get_peer_data(DB_MIGRATION_VERSION_KEY)
+            != self._hydra_cli.get_version()["version"]
+        )
+
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Event Handler for database created event."""
         logger.info("Retrieved database details")
-
-        if not self.unit.is_leader():
-            # TODO: Observe leader_elected event
-            logger.info("Unit does not have leadership")
-            self.unit.status = WaitingStatus("Unit waiting for leadership to run the migration")
-            return
 
         if not self._container.can_connect():
             event.defer()
@@ -442,27 +447,36 @@ class HydraCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting to connect to Hydra container")
             return
 
+        if not self._peers:
+            self.unit.status = WaitingStatus("Waiting for peer relation")
+            event.defer()
+            return
+
         self.unit.status = MaintenanceStatus(
             "Configuring container and resources for database connection"
         )
 
-        if not self._hydra_service_is_created:
-            event.defer()
-            self.unit.status = WaitingStatus("Waiting for Hydra service")
-            logger.info("Hydra service is absent. Deferring the event.")
-            return
-
         logger.info("Updating Hydra config and restarting service")
+        self._container.add_layer(self._container_name, self._hydra_layer, combine=True)
         self._container.push(self._hydra_config_path, self._render_conf_file(), make_dirs=True)
 
-        try:
-            self._run_sql_migration(set_timeout=True)
-        except ExecError as err:
-            logger.error(f"Exited with code {err.exit_code}. Stderr: {err.stderr}")
+        if not self._migration_is_needed():
+            self._container.start(self._container_name)
+            self.unit.status = ActiveStatus()
+            return
+
+        if not self.unit.is_leader():
+            logger.info("Unit does not have leadership")
+            self.unit.status = WaitingStatus("Unit waiting for leadership to run the migration")
+            event.defer()
+            return
+
+        if not self._run_sql_migration():
             self.unit.status = BlockedStatus("Database migration job failed")
             logger.error("Automigration job failed, please use the run-migration action")
             return
 
+        self._set_peer_data(DB_MIGRATION_VERSION_KEY, self._hydra_cli.get_version()["version"])
         self._container.start(self._container_name)
         self.unit.status = ActiveStatus()
 
@@ -473,17 +487,16 @@ class HydraCharm(CharmBase):
     def _on_run_migration(self, event: ActionEvent) -> None:
         """Runs the migration as an action response."""
         logger.info("Executing database migration initiated by user")
-        try:
-            self._run_sql_migration(set_timeout=False)
-        except ExecError as err:
-            logger.error(f"Exited with code {err.exit_code}. Stderr: {err.stderr}")
+        if not self._run_sql_migration():
             event.fail("Execution failed, please inspect the logs")
             return
+        event.log("Successfully ran migration")
 
     def _on_database_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Event Handler for database relation departed event."""
         logger.error("Missing required relation with postgresql")
         self.model.unit.status = BlockedStatus("Missing required relation with postgresql")
+        self._pop_peer_data(DB_MIGRATION_VERSION_KEY)
         if self._container.can_connect():
             self._container.stop(self._container_name)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -320,7 +320,7 @@ async def test_rotate_keys(ops_test: OpsTest) -> None:
 
 
 async def test_hydra_scale_up(ops_test: OpsTest) -> None:
-    """Check that kratos works after it is scaled up."""
+    """Check that hydra works after it is scaled up."""
     app = ops_test.model.applications[APP_NAME]
 
     await app.scale(3)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,6 +29,12 @@ async def get_unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> s
     return status["applications"][app_name]["units"][f"{app_name}/{unit_num}"]["address"]
 
 
+async def get_app_address(ops_test: OpsTest, app_name: str) -> str:
+    """Get address of an app."""
+    status = await ops_test.model.get_status()  # noqa: F821
+    return status["applications"][app_name]["public-address"]
+
+
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build hydra and deploy it with required charms and relations."""
@@ -311,3 +317,23 @@ async def test_rotate_keys(ops_test: OpsTest) -> None:
 
     assert any(jwk["kid"] == new_kid for jwk in new_jwks.json()["keys"])
     assert len(new_jwks.json()["keys"]) == len(jwks.json()["keys"]) + 1
+
+
+async def test_hydra_scale_up(ops_test: OpsTest) -> None:
+    """Check that kratos works after it is scaled up."""
+    app = ops_test.model.applications[APP_NAME]
+
+    await app.scale(3)
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=True,
+        timeout=1000,
+    )
+
+    admin_address = await get_app_address(ops_test, TRAEFIK_ADMIN_APP)
+    health_check_url = f"http://{admin_address}/{ops_test.model.name}-{APP_NAME}/health/ready"
+    resp = requests.get(health_check_url)
+
+    assert resp.status_code == 200

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -145,6 +145,11 @@ def mocked_run_migration(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("charm.HydraCLI.run_migration", return_value=None)
 
 
+@pytest.fixture()
+def mocked_migration_is_needed(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charm.HydraCharm._migration_is_needed", return_value=False)
+
+
 @pytest.fixture(autouse=True)
 def mocked_get_version(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch("charm.HydraCLI.get_version", return_value=None)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,12 +34,6 @@ def mocked_hydra_is_running(mocker: MockerFixture) -> Generator:
 
 
 @pytest.fixture()
-def mocked_sql_migration(mocker: MockerFixture) -> Generator:
-    mocked_sql_migration = mocker.patch("charm.HydraCharm._run_sql_migration")
-    yield mocked_sql_migration
-
-
-@pytest.fixture()
 def hydra_cli_client_json() -> Dict:
     return {
         "client_id": "07b318cf-9a9f-47b2-a288-972e671936a1",
@@ -144,6 +138,22 @@ def mocked_create_jwk(mocker: MockerFixture) -> Generator:
         ],
     }
     yield mock
+
+
+@pytest.fixture()
+def mocked_run_migration(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charm.HydraCLI.run_migration", return_value=None)
+
+
+@pytest.fixture(autouse=True)
+def mocked_get_version(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.patch("charm.HydraCLI.get_version", return_value=None)
+    mock.return_value = {
+        "version": "1.0.1",
+        "git_hash": "fasd23541235123321dfsdgsadg",
+        "build_time": "2023-06-13 16:42:24.609532580+03:00",
+    }
+    return mock
 
 
 @pytest.fixture()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,6 @@ import yaml
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ExecError
 from ops.testing import Harness
-from pytest_mock import MockerFixture
 from test_oauth_requirer import CLIENT_CONFIG  # type: ignore
 
 CONTAINER_NAME = "hydra"
@@ -185,7 +184,9 @@ def test_relation_departed(harness: Harness, mocked_run_migration: MagicMock) ->
     assert harness.charm.unit.status == BlockedStatus("Missing required relation with postgresql")
 
 
-def test_pebble_container_can_connect(harness: Harness, mocked_migration_is_needed: MagicMock) -> None:
+def test_pebble_container_can_connect(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
     setup_postgres_relation(harness)
     harness.set_can_connect(CONTAINER_NAME, True)
 
@@ -1102,7 +1103,9 @@ def test_rotate_key_action(
     event.set_results.assert_called_with({"new-key-id": ret["keys"][0]["kid"]})
 
 
-def test_on_pebble_ready_with_loki(harness: Harness, mocked_migration_is_needed: MagicMock) -> None:
+def test_on_pebble_ready_with_loki(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     setup_postgres_relation(harness)
     container = harness.model.unit.get_container(CONTAINER_NAME)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -187,6 +187,7 @@ def test_relation_departed(harness: Harness, mocked_run_migration: MagicMock) ->
 
 def test_pebble_container_can_connect(harness: Harness, mocked_run_migration: MagicMock) -> None:
     setup_postgres_relation(harness)
+    setup_peer_relation(harness)
     harness.set_can_connect(CONTAINER_NAME, True)
 
     harness.charm.on.hydra_pebble_ready.emit(CONTAINER_NAME)
@@ -405,13 +406,16 @@ def test_config_updated_on_ingress_relation_joined(harness: Harness) -> None:
     assert yaml.safe_load(harness.charm._render_conf_file()) == expected_config
 
 
-def test_hydra_config_on_pebble_ready_without_ingress_relation_data(harness: Harness) -> None:
+def test_hydra_config_on_pebble_ready_without_ingress_relation_data(
+    harness: Harness, mocked_run_migration: MagicMock
+) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
 
     # set relation without data
     relation_id = harness.add_relation("public-ingress", "public-traefik")
     harness.add_relation_unit(relation_id, "public-traefik/0")
 
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
     harness.charm.on.hydra_pebble_ready.emit(CONTAINER_NAME)
 
@@ -801,6 +805,7 @@ def test_config_updated_with_login_ui_endpoints_interface(
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.hydra_pebble_ready.emit(CONTAINER_NAME)
     setup_postgres_relation(harness)
+    setup_peer_relation(harness)
     (_, login_databag) = setup_login_ui_relation(harness)
 
     expected_config = {
@@ -853,6 +858,7 @@ def test_config_updated_with_login_ui_endpoints_proxy_down_interface(
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.hydra_pebble_ready.emit(CONTAINER_NAME)
     setup_postgres_relation(harness)
+    setup_peer_relation(harness)
     setup_login_ui_without_proxy_relation(harness)
 
     expected_config = {


### PR DESCRIPTION
Store the migration version in the peer relation. This allows us to be able to tell if the migration has been run and also when upgrading, if a migration needs to run. 

Currently our rocks don't have a version, but we are going to fix it this pulse

Closes #78 