### PR TITLE
Add custom event for oauth `relation-broken` and remove provider data on `relation-departed`

### DIFF
--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -209,6 +209,9 @@ class OAuthRelation(Object):
     """A class containing helper methods for oauth relation."""
 
     def _pop_relation_data(self, relation_id: Relation) -> None:
+        if not self.model.unit.is_leader():
+            return
+
         if len(self.model.relations) == 0:
             return
 


### PR DESCRIPTION
This PR:
- removes the provider relation data on `relation-departed`
- adds custom `on_oauth_info_removed` event to handle `relation-broken` in order to notify the requirer charm that the relation data was removed

closes https://github.com/canonical/hydra-operator/issues/81
