### PR TITLE
IAM-378-Add alert rules to Hydra operator

### DIFF
--- a/src/loki_alert_rules/hydra_high_severity_log.rule
+++ b/src/loki_alert_rules/hydra_high_severity_log.rule
@@ -2,13 +2,13 @@ groups:
 - name: HydraHighSeverityLog
   rules:
   - alert: LowFrequencyHighSeverityLog
-    expr: sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) > 0 and sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) < 100
+    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 0 and sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) < 100
     labels:
       severity: warning
     annotations:
       summary: "Logs with level error or above found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs is low."
   - alert: HighFrequencyHighSeverityLog
-    expr: sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) > 100
+    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 100
     labels:
       severity: error
     annotations:

--- a/src/loki_alert_rules/hydra_high_severity_log.rule
+++ b/src/loki_alert_rules/hydra_high_severity_log.rule
@@ -2,37 +2,37 @@ groups:
 - name: HydraHighSeverityLog
   rules:
   - alert: ErrorLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 0
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) > 0
     labels:
       severity: warning
     annotations:
       message: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is low."
   - alert: ErrorLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 100
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) > 100
     labels:
       severity: error
     annotations:
       summary: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is high."
   - alert: CriticalLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 0
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) > 0
     labels:
       severity: warning
     annotations:
       message: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
   - alert: CriticalLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 100
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) > 100
     labels:
       severity: error
     annotations:
       summary: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is high."
   - alert: FatalLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 0
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) > 0
     labels:
       severity: warning
     annotations:
       message: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
   - alert: FatalLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 100
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) > 100
     labels:
       severity: error
     annotations:

--- a/src/loki_alert_rules/hydra_high_severity_log.rule
+++ b/src/loki_alert_rules/hydra_high_severity_log.rule
@@ -1,0 +1,39 @@
+groups:
+- name: HydraHighSeverityLog
+  rules:
+  - alert: ErrorLevelLog
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 0
+    labels:
+      severity: warning
+    annotations:
+      message: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is low."
+  - alert: ErrorLevelLogHighFrequency
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 100
+    labels:
+      severity: error
+    annotations:
+      summary: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is high."
+  - alert: CriticalLevelLog
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 0
+    labels:
+      severity: warning
+    annotations:
+      message: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
+  - alert: CriticalLevelLogHighFrequency
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 100
+    labels:
+      severity: error
+    annotations:
+      summary: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is high."
+  - alert: FatalLevelLog
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 0
+    labels:
+      severity: warning
+    annotations:
+      message: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
+  - alert: FatalLevelLogHighFrequency
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 100
+    labels:
+      severity: error
+    annotations:
+      summary: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level fatal is high."

--- a/src/loki_alert_rules/hydra_high_severity_log.rule
+++ b/src/loki_alert_rules/hydra_high_severity_log.rule
@@ -1,39 +1,15 @@
 groups:
 - name: HydraHighSeverityLog
   rules:
-  - alert: ErrorLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) > 0
+  - alert: LowFrequencyHighSeverityLog
+    expr: sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) > 0 and sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) < 100
     labels:
       severity: warning
     annotations:
-      message: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is low."
-  - alert: ErrorLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) > 100
+      summary: "Logs with level error or above found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs is low."
+  - alert: HighFrequencyHighSeverityLog
+    expr: sum by(severity) (count_over_time({%%juju_topology%%} | json | severity =~ `error|fatal|critical` [5m])) > 100
     labels:
       severity: error
     annotations:
-      summary: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is high."
-  - alert: CriticalLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) > 0
-    labels:
-      severity: warning
-    annotations:
-      message: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
-  - alert: CriticalLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) > 100
-    labels:
-      severity: error
-    annotations:
-      summary: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is high."
-  - alert: FatalLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) > 0
-    labels:
-      severity: warning
-    annotations:
-      message: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
-  - alert: FatalLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) > 100
-    labels:
-      severity: error
-    annotations:
-      summary: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level fatal is high."
+      summary: "Logs with level error or above found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs is high."

--- a/src/prometheus_alert_rules/hydra_unavailable.rule
+++ b/src/prometheus_alert_rules/hydra_unavailable.rule
@@ -1,0 +1,31 @@
+groups:
+- name: HydraUnavailable
+  rules:
+  - alert: HydraUnavailable-one
+    expr: sum(up) + 1 == count(up)
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "One unit of {{ $labels.juju_application }} in model {{ $labels.juju_model }} is down"
+  - alert: HydraUnavailable-multiple
+    expr: sum(up) + 1 < count(up)
+    for: 1m
+    labels:
+      severity: error
+    annotations:
+      summary: "Multiple units of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
+  - alert: HydraUnavailable-all-except-one
+    expr: sum(up) == 1 and 1 < count(up)
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: "All but one unit of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
+  - alert: HydraUnavailable-all
+    expr: sum(up) == 0
+    for: 1m
+    labels:
+      severity: fatal
+    annotations:
+      summary: "All units of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"


### PR DESCRIPTION
Added alert rules to Hydra

# TESTING

To test Hydra alerts, you will need the cos-lite bundle, and the data backend:
```
juju deploy cos-lite --trust
juju deploy postgresql-k8s --trust
```

Pack and deploy Hydra (in operator root directory):

```
charmcraft pack
juju deploy ./hydra*.charm  --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml) --trust
juju integrate hydra postgresql-k8s
```

# Integrations:

You need to integrate the hydra operator with prometheus, loki:

```
juju integrate hydra prometheus
juju integrate hydra loki
```

You can verify the alerts on the Grafana's UI interface. After this you may access Grafana's UI with your browser. The url is grafana-ip:3000. Username is admin, you can get the password with `juju run grafana/0 get-admin-password`

On the Grafana interface you should be able to find options bar on the left side of the screen. Go to alerts. There you will see the available alerts from prometheus and loki. You can open them up with the arrow on the left to see more details, or to open a graph mapping the result of the alert query over time.