### PR TITLE
Update dashboards and alert rules

### DIFF
--- a/src/grafana_dashboards/hydra.json.tmpl
+++ b/src/grafana_dashboards/hydra.json.tmpl
@@ -25,6 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 16,
   "links": [
     {
       "asDropdown": false,
@@ -46,37 +47,100 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "List of units in the hydra juju deployment, and their status.",
+      "description": "Percentage of available Hydra units",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 0,
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "text": ":("
-                }
-              },
-              "type": "value"
-            }
-          ],
+          "decimals": 1,
+          "mappings": [],
+          "max": 1,
+          "min": -2,
+          "noValue": "0",
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
                 "color": "rgba(222, 3, 3, 0.9)",
                 "value": null
               },
               {
-                "color": "rgb(234, 245, 234)",
-                "value": 1
+                "color": "orange",
+                "value": 20
               },
               {
-                "color": "rgb(235, 244, 235)",
-                "value": 10000
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 25,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "9.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum(up{juju_charm=\"hydra\"}) / count(up{juju_charm=\"hydra\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Hydra Unit Availability",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${lokids}"
+      },
+      "description": "Visualisation for the number of log entries with levels error or above within 5 minutes spans.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [],
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -86,47 +150,40 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 10,
-        "x": 0,
+        "w": 7,
+        "x": 5,
         "y": 0
       },
-      "id": 20,
+      "id": 27,
       "links": [],
-      "maxDataPoints": 100,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "horizontal",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
         },
-        "text": {},
         "textMode": "auto"
       },
       "pluginVersion": "9.2.1",
       "targets": [
         {
           "datasource": {
-            "uid": "${prometheusds}"
+            "type": "loki",
+            "uid": "${lokids}"
           },
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "group by(juju_unit) (up{juju_charm=\"hydra\"})",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{juju_unit}}",
-          "refId": "A",
-          "step": 60
+          "expr": "sum(count_over_time({juju_charm=\"hydra\",juju_unit=~\"$juju_unit\"} | json | level=~\"error|fatal|critical\"[5m]))",
+          "queryType": "range",
+          "refId": "A"
         }
       ],
-      "title": "Hydra Unit Availability",
+      "title": "Hydra High Severity Log Entries",
       "type": "stat"
     },
     {
@@ -134,7 +191,82 @@
         "type": "loki",
         "uid": "${lokids}"
       },
-      "description": "Visualisation for the number of log entries with levels error or above within 5 minutes spans.",
+      "description": "Visualisation for the number of log entries with levels error or above within 5 minutes spans per unit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "displayName": "Error Logs",
+          "links": [],
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 12,
+        "y": 0
+      },
+      "id": 29,
+      "links": [],
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 2,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Value #LogLevels"
+          }
+        ]
+      },
+      "pluginVersion": "9.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${lokids}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(juju_unit)(count_over_time({juju_charm=\"hydra\",juju_unit=~\"$juju_unit\"} | json | level=~\"error|fatal|critical\"[$__range]))",
+          "legendFormat": "{{juju_unit}}",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Hydra High Severity Log Entries",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "Rate of incoming traffic grouped by endpoints and status codes",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -147,7 +279,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 5,
+            "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -155,12 +287,12 @@
               "viz": false
             },
             "lineInterpolation": "linear",
-            "lineWidth": 2,
+            "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -170,7 +302,191 @@
               "mode": "off"
             }
           },
-          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 0,
+        "y": 10
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(endpoint, code) (rate(http_requests_total{juju_charm=\"hydra\",juju_unit=~\"$juju_unit\"}[5m]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rate of incoming traffic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "Changes in the rate of outgoing response codes  over 5 minutes",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 11,
+        "y": 10
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(status_bucket) (rate(http_requests_statuses_total{juju_charm=\"hydra\",juju_unit=~\"$juju_unit\"}[5m]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Hydra response status codes rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -185,73 +501,17 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "s"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "400"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#447EBC",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "500"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#BF1B00",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "error"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 10,
-        "w": 10,
-        "x": 10,
-        "y": 0
+        "w": 23,
+        "x": 0,
+        "y": 20
       },
-      "id": 23,
-      "links": [],
+      "id": 35,
       "options": {
         "legend": {
           "calcs": [],
@@ -264,21 +524,20 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "8.1.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "loki",
-            "uid": "${lokids}"
+            "type": "prometheus",
+            "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "sum by (level) (count_over_time({juju_charm=\"hydra\"} | json | level =~ `error|fatal|critical` [5m]))",
-          "queryType": "range",
+          "expr": "histogram_quantile(0.9, sum by(le, endpoint) (rate(http_requests_duration_seconds_bucket{juju_charm=\"hydra\",juju_unit=~\"$juju_unit\"}[5m])))",
+          "legendFormat": "__auto",
           "range": true,
-          "refId": "LogLevels"
+          "refId": "A"
         }
       ],
-      "title": "Hydra High Severity Log Entries",
+      "title": "p90",
       "type": "timeseries"
     }
   ],
@@ -295,6 +554,135 @@
   "templating": {
     "list": [
       {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju unit",
+        "multi": true,
+        "name": "juju_unit",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju application",
+        "multi": true,
+        "name": "juju_application",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model uuid",
+        "multi": true,
+        "name": "juju_model_uuid",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up,juju_model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model",
+        "multi": true,
+        "name": "juju_model",
+        "options": [],
+        "query": {
+          "query": "label_values(up,juju_model)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "juju_iam_5358b275-84e0-4e92-818e-1046ac5e704d_prometheus_0",
+          "value": "juju_iam_5358b275-84e0-4e92-818e-1046ac5e704d_prometheus_0"
+        },
         "hide": 0,
         "includeAll": false,
         "multi": false,
@@ -308,6 +696,11 @@
         "type": "datasource"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "juju_iam_5358b275-84e0-4e92-818e-1046ac5e704d_loki_0",
+          "value": "juju_iam_5358b275-84e0-4e92-818e-1046ac5e704d_loki_0"
+        },
         "hide": 0,
         "includeAll": false,
         "multi": false,

--- a/src/loki_alert_rules/hydra_high_severity_log.rule
+++ b/src/loki_alert_rules/hydra_high_severity_log.rule
@@ -1,12 +1,6 @@
 groups:
 - name: HydraHighSeverityLog
   rules:
-  - alert: LowFrequencyHighSeverityLog
-    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 0 and sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) < 100
-    labels:
-      severity: warning
-    annotations:
-      summary: "Logs with level error or above found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs is low."
   - alert: HighFrequencyHighSeverityLog
     expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 100
     labels:

--- a/src/prometheus_alert_rules/hydra_unavailable.rule
+++ b/src/prometheus_alert_rules/hydra_unavailable.rule
@@ -1,27 +1,13 @@
 groups:
 - name: HydraUnavailable
   rules:
-  - alert: HydraUnavailable-one
-    expr: sum(up) + 1 == count(up)
-    for: 1m
-    labels:
-      severity: warning
-    annotations:
-      summary: "One unit of {{ $labels.juju_application }} in model {{ $labels.juju_model }} is down"
   - alert: HydraUnavailable-multiple
-    expr: sum(up) + 1 < count(up)
+    expr: sum(up) / count(up) < 0.7
     for: 1m
     labels:
       severity: error
     annotations:
-      summary: "Multiple units of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
-  - alert: HydraUnavailable-all-except-one
-    expr: sum(up) == 1 and 1 < count(up)
-    for: 1m
-    labels:
-      severity: critical
-    annotations:
-      summary: "All but one unit of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
+      summary: "30% of units of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
   - alert: HydraUnavailable-all
     expr: sum(up) == 0
     for: 1m


### PR DESCRIPTION
[IAM-486](https://warthogs.atlassian.net/browse/IAM-486)
[IAM-488](https://warthogs.atlassian.net/browse/IAM-488)

Updates the grafana dashboards:
![image](https://github.com/canonical/hydra-operator/assets/19745916/fe7666ea-7f14-4c65-aef7-10918e6660b8)
![image](https://github.com/canonical/hydra-operator/assets/19745916/bcece528-6c04-4f4a-913a-3597e26a82ed)

These changes were based on https://github.com/canonical/hydra-operator/pull/90#discussion_r1263706081. Couldn't remove the unused variables.

Updates the alert rules
![image](https://github.com/canonical/hydra-operator/assets/19745916/e8dfe91b-ea04-45ed-8b82-d2e9df7d64fb)
![image](https://github.com/canonical/hydra-operator/assets/19745916/9ea47db5-ee32-46a4-9c4f-5f94d205664f)


[IAM-486]: https://warthogs.atlassian.net/browse/IAM-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IAM-488]: https://warthogs.atlassian.net/browse/IAM-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ