### PR TITLE
Bump hydra to 2.2.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   oci-image:
     type: oci-image
     description: OCI image for hydra container
-    upstream-source: ghcr.io/canonical/hydra:2.1.1
+    upstream-source: ghcr.io/canonical/hydra:2.2.0
 requires:
   pg-database:
     interface: postgresql_client

--- a/src/charm.py
+++ b/src/charm.py
@@ -619,6 +619,9 @@ class HydraCharm(CharmBase):
         self._set_peer_data(self._migration_peer_data_key, self._hydra_cli.get_version())
         event.log("Updated migration version in peer data.")
 
+        if self.unit.status == WaitingStatus("Waiting for migration to run"):
+            self._handle_status_update_config(event)
+
     def _on_database_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Event Handler for database relation departed event."""
         self.unit.status = BlockedStatus("Missing required relation with postgresql")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1179,3 +1179,36 @@ def test_timeout_on_run_migration_action(
 
     mocked_run_migration.assert_called_once()
     event.fail.assert_called()
+
+
+def test_unit_status_before_run_migration_action(
+    harness: Harness,
+    mocked_migration_is_needed: MagicMock,
+    mocked_run_migration: MagicMock,
+    mocked_get_secrets: MagicMock,
+) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
+    mocked_migration_is_needed.return_value = True
+    setup_peer_relation(harness)
+    setup_ingress_relation(harness, "public")
+    setup_postgres_relation(harness)
+    assert harness.charm.unit.status == WaitingStatus("Waiting for migration to run")
+
+
+def test_unit_status_after_run_migration_action(
+    harness: Harness,
+    mocked_migration_is_needed: MagicMock,
+    mocked_run_migration: MagicMock,
+    mocked_get_secrets: MagicMock,
+) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
+    mocked_migration_is_needed.return_value = True
+    setup_peer_relation(harness)
+    setup_ingress_relation(harness, "public")
+    setup_postgres_relation(harness)
+
+    mocked_migration_is_needed.return_value = False
+    event = MagicMock()
+    harness.charm._on_run_migration(event)
+
+    assert isinstance(harness.model.unit.status, ActiveStatus)


### PR DESCRIPTION
This PR:
- updates the hydra image to v2.2.0 
- fixes a bug related to status handling:
When hydra requires database migration after an upgrade, it goes to `WaitingStatus`. After the migration is successfully run, it still remains in that status because the `pebble-ready` hook is not re-run.
This PR fixes that by calling `_handle_status_update_config` method after completing the migration.

## Testing instructions
1. Deploy the latest hydra:
`juju deploy hydra --channel latest/edge trust`
2. Fetch this fork and build the charm locally.
3. Upgrade the charm and run migration:
`juju refresh hydra --debug --trust --path ./hydra_ubuntu-22.04-amd64.charm --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)`
`juju run hydra/0 run-migration`