### PR TITLE
chore: replace black with ruff as the formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,15 +9,23 @@ repos:
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
     - id: trailing-whitespace
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+      - tomli
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
+  hooks:
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-- repo: https://github.com/psf/black
-  rev: 24.4.0
-  hooks:
-  - id: black
+    - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.9.0
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ enhancements to this operator.
 ## Developing
 
 You can use the environments created by `tox` for development. It helps
-install `pre-commit` and `mypy` type checker.
+install `pre-commit`, `mypy` type checker, linting tools, and formatting tools.
 
 ```shell
 tox -e dev

--- a/fmt-requirements.txt
+++ b/fmt-requirements.txt
@@ -1,2 +1,2 @@
-black
 isort
+ruff

--- a/lib/charms/hydra/v0/hydra_endpoints.py
+++ b/lib/charms/hydra/v0/hydra_endpoints.py
@@ -95,12 +95,10 @@ class HydraEndpointsProvider(Object):
 
         relations = self.model.relations[self._relation_name]
         for relation in relations:
-            relation.data[self._charm.app].update(
-                {
-                    "admin_endpoint": admin_endpoint,
-                    "public_endpoint": public_endpoint,
-                }
-            )
+            relation.data[self._charm.app].update({
+                "admin_endpoint": admin_endpoint,
+                "public_endpoint": public_endpoint,
+            })
 
 
 class HydraEndpointsRelationError(Exception):

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -799,5 +799,5 @@ class OAuthProvider(OAuthRelation):
         # TODO: What if we are refreshing the client_secret? We need to add a
         # new revision for that
         secret = self._create_juju_secret(client_secret, relation)
-        data = dict(client_id=client_id, client_secret_id=secret.id)
+        data = {"client_id": client_id, "client_secret_id": secret.id}
         relation.data[self.model.app].update(_dump_data(data))

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,9 +1,3 @@
-black
-flake8==6.1.0
-flake8-docstrings
-flake8-copyright
-flake8-builtins
-pyproject-flake8
-pep8-naming
-isort
 codespell
+isort
+ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,33 +12,59 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
+# Linting and formatting tools configuration
+[tool.codespell]
+# https://github.com/codespell-project/codespell
+skip = ".git,.tox,build,lib,venv,.venv,.mypy_cache,icon.svg,__pycache__"
 
 [tool.isort]
+# Profiles: https://pycqa.github.io/isort/docs/configuration/profiles.html
 line_length = 99
 profile = "black"
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+[tool.ruff]
+# Default settings: https://docs.astral.sh/ruff/configuration/
+# Settings: https://docs.astral.sh/ruff/settings/
+line-length = 99
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py", "lib/charms/hydra/**/*.py"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+target-version = "py38"
+preview = true
 
+[tool.ruff.lint]
+# Rules: https://docs.astral.sh/ruff/rules/
+select = ["E", "W", "F", "C", "N", "D", "CPY"]
+ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+    "E501",
+    "N818"
+]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.flake8-copyright]
+author = "Canonical Ltd."
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.mypy]
 pretty = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,7 +58,6 @@ from ops.model import (
     ActiveStatus,
     BlockedStatus,
     MaintenanceStatus,
-    ModelError,
     Relation,
     Secret,
     SecretNotFoundError,
@@ -350,13 +349,11 @@ class HydraCharm(CharmBase):
         relation_id = self.database.relations[0].id
         relation_data = self.database.fetch_relation_data()[relation_id]
 
-        if not all(
-            [
-                relation_data.get("username"),
-                relation_data.get("password"),
-                relation_data.get("endpoints"),
-            ]
-        ):
+        if not all([
+            relation_data.get("username"),
+            relation_data.get("password"),
+            relation_data.get("endpoints"),
+        ]):
             return None
 
         return {
@@ -701,7 +698,7 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
-        self._set_oauth_relation_peer_data(event.relation_id, dict(client_id=client["client_id"]))
+        self._set_oauth_relation_peer_data(event.relation_id, {"client_id": client["client_id"]})
         self.oauth.set_client_credentials_in_relation_data(
             event.relation_id, client["client_id"], client["client_secret"]
         )
@@ -767,17 +764,15 @@ class HydraCharm(CharmBase):
 
         event.log("Creating client")
 
-        cmd_kwargs = remove_none_values(
-            {
-                "audience": event.params.get("audience"),
-                "grant_type": event.params.get("grant-types"),
-                "redirect_uri": event.params.get("redirect-uris"),
-                "response_type": event.params.get("response-types"),
-                "scope": event.params.get("scope"),
-                "client_secret": event.params.get("client-secret"),
-                "token_endpoint_auth_method": event.params.get("token-endpoint-auth-method"),
-            }
-        )
+        cmd_kwargs = remove_none_values({
+            "audience": event.params.get("audience"),
+            "grant_type": event.params.get("grant-types"),
+            "redirect_uri": event.params.get("redirect-uris"),
+            "response_type": event.params.get("response-types"),
+            "scope": event.params.get("scope"),
+            "client_secret": event.params.get("client-secret"),
+            "token_endpoint_auth_method": event.params.get("token-endpoint-auth-method"),
+        })
 
         try:
             client = self._hydra_cli.create_client(**cmd_kwargs)
@@ -786,18 +781,16 @@ class HydraCharm(CharmBase):
             return
 
         event.log("Successfully created client")
-        event.set_results(
-            {
-                "client-id": client.get("client_id"),
-                "client-secret": client.get("client_secret"),
-                "audience": client.get("audience"),
-                "grant-types": ", ".join(client.get("grant_types", [])),
-                "redirect-uris": ", ".join(client.get("redirect_uris", [])),
-                "response-types": ", ".join(client.get("response_types", [])),
-                "scope": client.get("scope"),
-                "token-endpoint-auth-method": client.get("token_endpoint_auth_method"),
-            }
-        )
+        event.set_results({
+            "client-id": client.get("client_id"),
+            "client-secret": client.get("client_secret"),
+            "audience": client.get("audience"),
+            "grant-types": ", ".join(client.get("grant_types", [])),
+            "redirect-uris": ", ".join(client.get("redirect_uris", [])),
+            "response-types": ", ".join(client.get("response_types", [])),
+            "scope": client.get("scope"),
+            "token-endpoint-auth-method": client.get("token_endpoint_auth_method"),
+        })
 
     def _on_get_oauth_client_info_action(self, event: ActionEvent) -> None:
         if not self._hydra_service_is_running:
@@ -822,12 +815,10 @@ class HydraCharm(CharmBase):
         event.log(f"Successfully fetched client: {client_id}")
         # We dump everything in the result, but we have to first convert it to the
         # format the juju action expects
-        event.set_results(
-            {
-                k.replace("_", "-"): ", ".join(v) if isinstance(v, list) else v
-                for k, v in client.items()
-            }
-        )
+        event.set_results({
+            k.replace("_", "-"): ", ".join(v) if isinstance(v, list) else v
+            for k, v in client.items()
+        })
 
     def _on_update_oauth_client_action(self, event: ActionEvent) -> None:
         if not self._hydra_service_is_running:
@@ -853,19 +844,16 @@ class HydraCharm(CharmBase):
             )
             return
 
-        cmd_kwargs = remove_none_values(
-            {
-                "audience": event.params.get("audience") or client.get("audience"),
-                "grant_type": event.params.get("grant-types") or client.get("grant_types"),
-                "redirect_uri": event.params.get("redirect-uris") or client.get("redirect_uris"),
-                "response_type": event.params.get("response-types")
-                or client.get("response_types"),
-                "scope": event.params.get("scope") or client["scope"].split(" "),
-                "client_secret": event.params.get("client-secret") or client.get("client_secret"),
-                "token_endpoint_auth_method": event.params.get("token-endpoint-auth-method")
-                or client.get("token_endpoint_auth_method"),
-            }
-        )
+        cmd_kwargs = remove_none_values({
+            "audience": event.params.get("audience") or client.get("audience"),
+            "grant_type": event.params.get("grant-types") or client.get("grant_types"),
+            "redirect_uri": event.params.get("redirect-uris") or client.get("redirect_uris"),
+            "response_type": event.params.get("response-types") or client.get("response_types"),
+            "scope": event.params.get("scope") or client["scope"].split(" "),
+            "client_secret": event.params.get("client-secret") or client.get("client_secret"),
+            "token_endpoint_auth_method": event.params.get("token-endpoint-auth-method")
+            or client.get("token_endpoint_auth_method"),
+        })
         event.log(f"Updating client: {client_id}")
         try:
             client = self._hydra_cli.update_client(client_id, **cmd_kwargs)
@@ -874,18 +862,16 @@ class HydraCharm(CharmBase):
             return
 
         event.log(f"Successfully updated client: {client_id}")
-        event.set_results(
-            {
-                "client-id": client.get("client_id"),
-                "client-secret": client.get("client_secret"),
-                "audience": client.get("audience"),
-                "grant-types": ", ".join(client.get("grant_types", [])),
-                "redirect-uris": ", ".join(client.get("redirect_uris", [])),
-                "response-types": ", ".join(client.get("response_types", [])),
-                "scope": client.get("scope"),
-                "token-endpoint-auth-method": client.get("token_endpoint_auth_method"),
-            }
-        )
+        event.set_results({
+            "client-id": client.get("client_id"),
+            "client-secret": client.get("client_secret"),
+            "audience": client.get("audience"),
+            "grant-types": ", ".join(client.get("grant_types", [])),
+            "redirect-uris": ", ".join(client.get("redirect_uris", [])),
+            "response-types": ", ".join(client.get("response_types", [])),
+            "scope": client.get("scope"),
+            "token-endpoint-auth-method": client.get("token_endpoint_auth_method"),
+        })
 
     def _on_delete_oauth_client_action(self, event: ActionEvent) -> None:
         if not self._hydra_service_is_running:

--- a/src/hydra_cli.py
+++ b/src/hydra_cli.py
@@ -3,7 +3,6 @@
 
 """A helper class for interacting with the hydra CLI."""
 
-
 import json
 import logging
 import re

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -101,23 +101,19 @@ def setup_loki_relation(harness: Harness) -> int:
     relation_id = harness.add_relation("logging", "loki-k8s")
     harness.add_relation_unit(relation_id, "loki-k8s/0")
     databag = {
-        "promtail_binary_zip_url": json.dumps(
-            {
-                "amd64": {
-                    "filename": "promtail-static-amd64",
-                    "zipsha": "543e333b0184e14015a42c3c9e9e66d2464aaa66eca48b29e185a6a18f67ab6d",
-                    "binsha": "17e2e271e65f793a9fbe81eab887b941e9d680abe82d5a0602888c50f5e0cac9",
-                    "url": "https://github.com/canonical/loki-k8s-operator/releases/download/promtail-v2.5.0/promtail-static-amd64.gz",
-                }
+        "promtail_binary_zip_url": json.dumps({
+            "amd64": {
+                "filename": "promtail-static-amd64",
+                "zipsha": "543e333b0184e14015a42c3c9e9e66d2464aaa66eca48b29e185a6a18f67ab6d",
+                "binsha": "17e2e271e65f793a9fbe81eab887b941e9d680abe82d5a0602888c50f5e0cac9",
+                "url": "https://github.com/canonical/loki-k8s-operator/releases/download/promtail-v2.5.0/promtail-static-amd64.gz",
             }
-        ),
+        }),
     }
     unit_databag = {
-        "endpoint": json.dumps(
-            {
-                "url": "http://loki-k8s-0.loki-k8s-endpoints.model0.svc.cluster.local:3100/loki/api/v1/push"
-            }
-        )
+        "endpoint": json.dumps({
+            "url": "http://loki-k8s-0.loki-k8s-endpoints.model0.svc.cluster.local:3100/loki/api/v1/push"
+        })
     }
     harness.update_relation_data(
         relation_id,
@@ -910,18 +906,16 @@ def test_create_oauth_client_action(
     harness.charm._on_create_oauth_client_action(event)
 
     ret = mocked_create_client.return_value
-    event.set_results.assert_called_with(
-        {
-            "client-id": ret.get("client_id"),
-            "client-secret": ret.get("client_secret"),
-            "audience": ret.get("audience"),
-            "grant-types": ", ".join(ret.get("grant_types")),
-            "redirect-uris": ", ".join(ret.get("redirect_uris")),
-            "response-types": ", ".join(ret.get("response_types")),
-            "scope": ret.get("scope"),
-            "token-endpoint-auth-method": ret.get("token_endpoint_auth_method"),
-        }
-    )
+    event.set_results.assert_called_with({
+        "client-id": ret.get("client_id"),
+        "client-secret": ret.get("client_secret"),
+        "audience": ret.get("audience"),
+        "grant-types": ", ".join(ret.get("grant_types")),
+        "redirect-uris": ", ".join(ret.get("redirect_uris")),
+        "response-types": ", ".join(ret.get("response_types")),
+        "scope": ret.get("scope"),
+        "token-endpoint-auth-method": ret.get("token_endpoint_auth_method"),
+    })
 
 
 def test_get_oauth_client_info_action(
@@ -936,9 +930,9 @@ def test_get_oauth_client_info_action(
 
     harness.charm._on_get_oauth_client_info_action(event)
 
-    event.set_results.assert_called_with(
-        {k.replace("_", "-"): ", ".join(v) if isinstance(v, list) else v for k, v in ret.items()}
-    )
+    event.set_results.assert_called_with({
+        k.replace("_", "-"): ", ".join(v) if isinstance(v, list) else v for k, v in ret.items()
+    })
 
 
 def test_update_oauth_client_action(
@@ -956,18 +950,16 @@ def test_update_oauth_client_action(
 
     harness.charm._on_update_oauth_client_action(event)
 
-    event.set_results.assert_called_with(
-        {
-            "client-id": ret.get("client_id"),
-            "client-secret": ret.get("client_secret"),
-            "audience": ret.get("audience"),
-            "grant-types": ", ".join(ret.get("grant_types")),
-            "redirect-uris": ", ".join(ret.get("redirect_uris")),
-            "response-types": ", ".join(ret.get("response_types")),
-            "scope": ret.get("scope"),
-            "token-endpoint-auth-method": ret.get("token_endpoint_auth_method"),
-        }
-    )
+    event.set_results.assert_called_with({
+        "client-id": ret.get("client_id"),
+        "client-secret": ret.get("client_secret"),
+        "audience": ret.get("audience"),
+        "grant-types": ", ".join(ret.get("grant_types")),
+        "redirect-uris": ", ".join(ret.get("redirect_uris")),
+        "response-types": ", ".join(ret.get("response_types")),
+        "scope": ret.get("scope"),
+        "token-endpoint-auth-method": ret.get("token_endpoint_auth_method"),
+    })
 
 
 def test_update_oauth_client_action_when_oauth_relation_client(

--- a/tox.ini
+++ b/tox.ini
@@ -28,30 +28,29 @@ deps =
     pre-commit
     mypy
     types-PyYAML
+    -r{toxinidir}/fmt-requirements.txt
+    -r{toxinidir}/lint-requirements.txt
 commands =
     pre-commit install -t commit-msg
 
 [testenv:fmt]
-description = Apply coding style standards to code
+description = Apply coding style standards
 deps =
     -r{toxinidir}/fmt-requirements.txt
 commands =
     isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
+    ; The tomli package is needed because https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file
+    tomli
     -r{toxinidir}/lint-requirements.txt
 commands =
-    codespell {[vars]lib_path}
-    codespell {toxinidir}/ --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.venv --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
+    codespell {toxinidir}/
     isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    ruff check --show-fixes {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This pull request:

- replaces black with ruff as the formatter
- fixes the lint and format issues with ruff
- keeps the `isort` to keep the original behaviors for import sorting
- puts the `codespell` configuration to the `pyproject.toml` file to be consistent with other tools