### PR TITLE
Add jwt_access_token field to relation databag

### DIFF
--- a/tests/unit/test_oauth_provider.py
+++ b/tests/unit/test_oauth_provider.py
@@ -82,6 +82,7 @@ def test_provider_info_in_relation_databag(harness: Harness) -> None:
         "scope": "openid profile email phone",
         "token_endpoint": "https://example.oidc.com/oauth2/token",
         "userinfo_endpoint": "https://example.oidc.com/userinfo",
+        "jwt_access_token": "False",
     }
 
 
@@ -115,6 +116,7 @@ def test_client_credentials_in_relation_databag_when_client_available(harness: H
         "token_endpoint": "https://example.oidc.com/oauth2/token",
         "userinfo_endpoint": "https://example.oidc.com/userinfo",
         "client_id": CLIENT_ID,
+        "jwt_access_token": "False",
     }
 
 

--- a/tests/unit/test_oauth_requirer.py
+++ b/tests/unit/test_oauth_requirer.py
@@ -47,6 +47,7 @@ def provider_info() -> Dict:
         "scope": "openid profile email phone",
         "token_endpoint": "https://example.oidc.com/oauth2/token",
         "userinfo_endpoint": "https://example.oidc.com/userinfo",
+        "jwt_access_token": "False",
     }
 
 
@@ -163,6 +164,7 @@ def test_get_provider_info_when_data_available(harness: Harness, provider_info: 
     assert expected_provider_info.scope == provider_info["scope"]
     assert expected_provider_info.token_endpoint == provider_info["token_endpoint"]
     assert expected_provider_info.userinfo_endpoint == provider_info["userinfo_endpoint"]
+    assert expected_provider_info.jwt_access_token == (provider_info["jwt_access_token"] == "True")
 
 
 def test_get_client_credentials_when_data_available(harness: Harness, provider_info: Dict) -> None:


### PR DESCRIPTION
After discussing it with @gtato it looks like we should add a jwt at field in the relation to allow it to be used with other providers other than hydra that support jwt access tokens.

If this is merged, I will update the charm relation interface