### PR TITLE
Fix charm publish action for Ubuntu 24.04

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,9 +53,15 @@ jobs:
           echo "setting output of destination_channel=$destination_channel"
           echo "::set-output name=destination_channel::$destination_channel"
 
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+      
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@934193396735701141a1decc3613818e412da606 # 2.6.3
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
+          destructive-mode: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -187,13 +187,9 @@ actions:
         default: RS256
         enumerate: [RS256, RS512, ES256, ES512, EdDSA]
 
-bases:
-  - build-on:
-      - name: "ubuntu"
-        channel: "22.04"
-    run-on:
-      - name: "ubuntu"
-        channel: "22.04"
+base: ubuntu@22.04
+platforms:
+  amd64:
 
 parts:
   charm:


### PR DESCRIPTION
## Description
Refactor operator to fix publish action for Ubuntu 24.04

## Changes
- set `destructive-mode: false` in publish step of the action
- add step to setup LXD
- edit charmcraft.yaml

Fixes #221 