### PR TITLE
feat: replace traefik with istio-ingress for public ingress

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -19,7 +19,7 @@ jobs:
 
   integration-test-microk8s:
     name: Integration tests (microk8s)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs:
       - unit-test
     steps:
@@ -31,7 +31,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.28-strict/stable
-          juju-channel: 3.4
+          juju-channel: 3.4/stable
+          microk8s-addons: "dns hostpath-storage metallb::10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,7 +97,7 @@ def database_integration(harness: Harness) -> int:
 
 @pytest.fixture
 def public_ingress_integration(harness: Harness) -> int:
-    return harness.add_relation(PUBLIC_INGRESS_INTEGRATION_NAME, "traefik-public")
+    return harness.add_relation(PUBLIC_INGRESS_INTEGRATION_NAME, "public-ingress")
 
 
 @pytest.fixture
@@ -124,7 +124,7 @@ def database_integration_data(harness: Harness, database_integration: int) -> No
 def public_ingress_integration_data(harness: Harness, public_ingress_integration: int) -> None:
     harness.update_relation_data(
         public_ingress_integration,
-        "traefik-public",
+        "public-ingress",
         {
             "ingress": '{"url": "https://hydra.ory.com"}',
         },


### PR DESCRIPTION
This pull request aims to drop traefik-k8s and use istio-ingress-k8s charm for public ingress.

Note:
- For internal ingress, we need the [feature support](https://github.com/canonical/istio-ingress-k8s-operator/issues/23) in istio-ingress-k8s. Therefore, we are still using the traefik-k8s charm for it. We'll come back to it when istio-ingress-k8s charm supports that.