### PR TITLE
feat: replace traefik with istio-ingress for public ingress

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.28-strict/stable
-          juju-channel: 3.4
+          juju-channel: 3.4/stable
+          microk8s-addons: "hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action

--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@ visit <https://www.ory.sh/docs/hydra/>.
 ## Usage
 
 ```shell
+# Deploy required charms
 juju deploy postgresql-k8s --channel edge --trust
+juju deploy istio-ingresss-k8s public-ingress --channel latest/edge --trust
+
+# Deploy hydra
 juju deploy hydra --trust
-juju integrate postgresql-k8s hydra
+
+# Integrate with required charms
+juju integrate hydra postgresql-k8s
+juju integrate hydra:public-ingress public-ingress
 ```
 
 You can follow the deployment status with `watch -c juju status --color`.
@@ -31,24 +38,19 @@ You can follow the deployment status with `watch -c juju status --color`.
 This charm requires an integration
 with [postgresql-k8s-operator](https://github.com/canonical/postgresql-k8s-operator).
 
-### Ingress
+### Public Ingress
 
-The Hydra Operator offers integration with
-the [traefik-k8s-operator](https://github.com/canonical/traefik-k8s-operator)
-for ingress. Hydra has two APIs which can be exposed through ingress, the public
-API and the admin API.
+This charm requires a `public-ingress` integration with
+the [istio-ingress-k8s](https://github.com/canonical/istio-ingress-k8s-operator)
+to expose the public API.
 
-If you have traefik deployed and configured in your hydra model, to provide
-ingress to the admin API run:
-
-```shell
-juju integrate traefik-admin hydra:admin-ingress
-```
-
-To provide ingress to the public API run:
+Make sure you've deployed
+the [istio-k8s](https://github.com/canonical/istio-k8s-operator) charm
+beforehand.
 
 ```shell
-juju integrate traefik-public hydra:public-ingress
+juju deploy istio-ingress-k8s public-ingress --channel latest/edge --trust
+juju integrate hydra:public-ingress public-ingress
 ```
 
 ### Kratos

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,7 +97,7 @@ def database_integration(harness: Harness) -> int:
 
 @pytest.fixture
 def public_ingress_integration(harness: Harness) -> int:
-    return harness.add_relation(PUBLIC_INGRESS_INTEGRATION_NAME, "traefik-public")
+    return harness.add_relation(PUBLIC_INGRESS_INTEGRATION_NAME, "public-ingress")
 
 
 @pytest.fixture
@@ -124,7 +124,7 @@ def database_integration_data(harness: Harness, database_integration: int) -> No
 def public_ingress_integration_data(harness: Harness, public_ingress_integration: int) -> None:
     harness.update_relation_data(
         public_ingress_integration,
-        "traefik-public",
+        "public-ingress",
         {
             "ingress": '{"url": "https://hydra.ory.com"}',
         },


### PR DESCRIPTION
This pull request aims to drop traefik-k8s and use istio-ingress-k8s charm for public ingress.

Note:
- For internal ingress, we need the [feature support](https://github.com/canonical/istio-ingress-k8s-operator/issues/23) in istio-ingress-k8s. Therefore, we are still using the traefik-k8s charm for it. We'll come back to it when istio-ingress-k8s charm supports that.