### PR TITLE
Handle client_created event being emitted multiple times

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -397,6 +397,10 @@ class HydraCharm(CharmBase):
             event.defer()
             return
 
+        if self.peer_data[f"oauth_{event.relation_id}"]:
+            logger.info("Got client_created event, but client already exists. Ignoring event")
+            return
+
         target_oauth_client = OAuthClient(
             **event.snapshot(),
             **{"metadata": {"integration-id": str(event.relation_id)}},


### PR DESCRIPTION
IAM-1240

Fixes the bug described in https://github.com/canonical/iam-bundle/issues/306, by adding a guard check using the peer relation.

I was unable to reproduce the issue on a unit test because harness does not raise an error when multiple juju secrets are created with the same label (juju raises an error).

My guess is that the error happens when we get multiple relation changed events on the oauth relation before the client is created which results in multiple `client_created` events being emitted (see https://github.com/canonical/hydra-operator/blob/main/lib/charms/hydra/v0/oauth.py#L716).

I was able to more easily reproduce it by changing the grafana scale to 3 in the overlay.I think that it can also happen with 1 grafana unit if the relation is created before the grafana unit is ready (according to https://juju.is/docs/sdk/relation-events#heading--relation-event-triggers, when a unit is added the relation-changed event is emitted), but I was unable to reproduce it.