### PR TITLE
fix: fix the lint ci and traefik charm in integration test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ profile = "black"
 line-length = 99
 include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py", "lib/charms/hydra/**/*.py"]
 extend-exclude = ["__pycache__", "*.egg_info"]
-target-version = "py38"
+target-version = "py312"
 preview = true
 
 [tool.ruff.lint]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -58,14 +58,14 @@ async def test_build_and_deploy(ops_test: OpsTest, local_charm: Path) -> None:
     await ops_test.model.deploy(
         TRAEFIK_CHARM,
         application_name=TRAEFIK_PUBLIC_APP,
-        channel="latest/edge",
+        channel="latest/stable",
         config={"external_hostname": PUBLIC_INGRESS_DOMAIN},
         trust=True,
     )
     await ops_test.model.deploy(
         TRAEFIK_CHARM,
         application_name=TRAEFIK_ADMIN_APP,
-        channel="latest/edge",
+        channel="latest/stable",
         config={"external_hostname": ADMIN_INGRESS_DOMAIN},
         trust=True,
     )


### PR DESCRIPTION
This pull request aims to

- fix the lint ci (due to an upgrade of ruff)
- use latest/stable traefik charms in integration tests