### PR TITLE
IAM-1623: enable extra cli args via juju actions

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -131,7 +131,7 @@ actions:
         description: A user-friendly name given to the client
         type: string
       metadata:
-        description: A JSON string with extra information relevant for the client
+        description: A comma-separated string of <key>=<value> with extra information relevant for the client, eg dept=IT
         type: string
       audience:
         description: A list with the allowed audience for the client
@@ -174,7 +174,7 @@ actions:
         description: A user-friendly name given to the client
         type: string
       metadata:
-        description: A JSON string with extra information relevant for the client
+        description: A comma-separated string of <key>=<value> with extra information relevant for the client, eg dept=IT
       audience:
         description: A list with the allowed audience for the client
         type: array

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -127,6 +127,12 @@ actions:
   create-oauth-client:
     description: Register an oauth client
     params:
+      name:
+        description: A user-friendly name given to the client
+        type: string
+      metadata:
+        description: A JSON string with extra information relevant for the client
+        type: string
       audience:
         description: A list with the allowed audience for the client
         type: array
@@ -164,6 +170,11 @@ actions:
       client-id:
         description: The client_id
         type: string
+      name:
+        description: A user-friendly name given to the client
+        type: string
+      metadata:
+        description: A JSON string with extra information relevant for the client
       audience:
         description: A list with the allowed audience for the client
         type: array

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -160,6 +160,9 @@ actions:
       token-endpoint-auth-method:
         description: The authentication method the client may use at the token endpoint.
         type: string
+      client-uri:
+        description: The client's uri, usually its homepage
+        type: string
   get-oauth-client-info:
     description: Get an oauth client's information
     params:
@@ -201,6 +204,9 @@ actions:
         type: string
       token-endpoint-auth-method:
         description: The authentication method the client may use at the token endpoint.
+        type: string
+      client-uri:
+        description: The client's uri, usually its homepage
         type: string
     required: ["client-id"]
   delete-oauth-client:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -130,6 +130,9 @@ actions:
       name:
         description: A user-friendly name given to the client
         type: string
+      contacts:
+        description: A list of contacts for the client
+        type: array
       metadata:
         description: A comma-separated string of <key>=<value> with extra information relevant for the client, eg dept=IT
         type: string
@@ -173,6 +176,9 @@ actions:
       name:
         description: A user-friendly name given to the client
         type: string
+      contacts:
+        description: A list of contacts for the client
+        type: array
       metadata:
         description: A comma-separated string of <key>=<value> with extra information relevant for the client, eg dept=IT
       audience:

--- a/src/cli.py
+++ b/src/cli.py
@@ -58,6 +58,10 @@ class OAuthClient(BaseModel):
         validation_alias=AliasChoices("client-name", "client_name", "name"),
         serialization_alias="name",
     )
+    contacts: Optional[list[str]] = Field(
+        default_factory=list,
+        serialization_alias="contacts",
+    )
 
     @property
     def managed_by_integration(self) -> bool:
@@ -111,6 +115,9 @@ class OAuthClient(BaseModel):
 
         if self.name:
             cmd_options.extend(["--name", self.name])
+
+        if self.contacts:
+            cmd_options.extend(["--contact", ",".join(self.contacts)])
 
         if self.grant_types:
             cmd_options.extend(["--grant-type", ",".join(self.grant_types)])

--- a/src/cli.py
+++ b/src/cli.py
@@ -62,12 +62,16 @@ class OAuthClient(BaseModel):
         default_factory=list,
         serialization_alias="contacts",
     )
+    client_uri: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("client-uri", "client_uri"),
+        serialization_alias="client-uri",
+    )
 
     @property
     def managed_by_integration(self) -> bool:
         return "integration-id" in self.metadata
 
-   
     @field_validator("redirect_uris", mode="before")
     @classmethod
     def deserialize_redirect_uris(cls, v: str | list[str]) -> list[str]:
@@ -115,6 +119,9 @@ class OAuthClient(BaseModel):
 
         if self.name:
             cmd_options.extend(["--name", self.name])
+
+        if self.client_uri:
+            cmd_options.extend(["--client-uri", self.client_uri])
 
         if self.contacts:
             cmd_options.extend(["--contact", ",".join(self.contacts)])

--- a/src/cli.py
+++ b/src/cli.py
@@ -36,7 +36,7 @@ class OAuthClient(BaseModel):
         validation_alias=AliasChoices("token-endpoint-auth-method", "token_endpoint_auth_method"),
         serialization_alias="token-endpoint-auth-method",
     )
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict, serialization_alias="metadata")
     audience: Optional[list[str]] = None
     client_id: Optional[str] = Field(
         default=None,
@@ -52,6 +52,11 @@ class OAuthClient(BaseModel):
         default=None,
         validation_alias=AliasChoices("grant-types", "grant_types"),
         serialization_alias="grant-types",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("client-name", "client_name", "name"),
+        serialization_alias="name",
     )
 
     @property
@@ -86,6 +91,9 @@ class OAuthClient(BaseModel):
 
         if self.audience:
             cmd_options.extend(["--audience", ",".join(self.audience)])
+
+        if self.name:
+            cmd_options.extend(["--name", self.name])
 
         if self.grant_types:
             cmd_options.extend(["--grant-type", ",".join(self.grant_types)])

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -161,7 +161,10 @@ class TestCreateOAuthClientAction:
 
         mocked_cli.assert_called_once()
         assert output.results["redirect-uris"] == [mocked_oauth_client_config["redirect_uri"]]
-        assert output.results["token-endpoint-auth-method"] == "client_secret_basic"
+        assert (
+            output.results["token-endpoint-auth-method"]
+            == mocked_oauth_client_config["token_endpoint_auth_method"]
+        )
 
 
 class TestGetOAuthClientInfoAction:
@@ -313,13 +316,24 @@ class TestUpdateOAuthClientAction:
 
         output = harness.run_action(
             "update-oauth-client",
-            {"client-id": "client_id", "redirect-uris": ["https://example.ory.com"]},
+            {
+                "client-id": "client_id",
+                "redirect-uris": ["https://example.ory.com"],
+                "contacts": ["test@canonical.com", "me@me.com"],
+                "client-uri": "https://example.com",
+                "metadata": "foo=bar,bar=foo",
+                "name": "test-client",
+            },
         )
         assert "Successfully updated the OAuth client client_id" in output.logs
 
         mocked_cli.assert_called_once()
         action_call_arg: OAuthClient = mocked_cli.call_args[0][0]
         assert action_call_arg.redirect_uris == ["https://example.ory.com"]
+        assert action_call_arg.contacts == ["test@canonical.com", "me@me.com"]
+        assert action_call_arg.client_uri == "https://example.com"
+        assert action_call_arg.metadata == {"foo": "bar", "bar": "foo"}
+        assert action_call_arg.name == "test-client"
 
 
 class TestDeleteOAuthClientAction:


### PR DESCRIPTION
- **feat: add name to the create and update actions**
- **fix: add serializer for metadata**
- **feat: expose contacts via cli**
- **feat: expose client-uri via cli**

---


example usage: 


```
shipperizer in ~/shipperizer/hydra-operator on IAM-1623 ● λ juju run --model iam hydra/leader create-oauth-client name=tosto redirect-uris='[https://myworkplace.canonical.com/authorize,https://myworkplace.staging.canonical.com/authorize,https://localhost:8080/authorize,http://localhost:8080/authorize]' response-types='[code]' scope='[openid,profile,email,offline_access]' metadata='me=foo,you=bar' contacts='[me@canon.me,you@me.com]' client-uri='https://me.com/info'

Running operation 65 with 1 task
  - task 66 on unit-hydra-0

Waiting for task 66...
client-id: aa24f35a-e0c4-4fbc-bca6-c08e59ac996f
client-secret: h2m5~avI3HdM6Jjuv7pqPGDz.j
client-uri: https://me.com/info
contacts: '[''me@canon.me'', ''you@me.com'']'
grant-types: '[''authorization_code'']'
metadata:
  me: foo
  you: bar
name: tosto
redirect-uris: '[''https://myworkplace.canonical.com/authorize'', ''https://myworkplace.staging.canonical.com/authorize'',
  ''https://localhost:8080/authorize'', ''http://localhost:8080/authorize'']'
response-types: '[''code'']'
scope: '[''openid'', ''profile'', ''email'', ''offline_access'']'
token-endpoint-auth-method: client_secret_basic

```


please pay extra attention to https://github.com/canonical/hydra-operator/pull/374/commits/9a5667c3f8fa546e16f853ed023478c5268a9e1b




----



closes https://github.com/canonical/hydra-operator/pull/375