### PR TITLE
build: add pythonpaths for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+pythonpath = ["src", "lib", "tests"]
 
 # Linting and formatting tools configuration
 [tool.codespell]


### PR DESCRIPTION
- This allows pytest to properly pick up the paths. Useful in an IDE, for example.