### PR TITLE
fix: remove the storedstate to fix the missing config file issue when the pod gets recreated

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -1,12 +1,9 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import logging
 from collections import ChainMap
-from pathlib import PurePath
-from typing import Optional
 
-from ops import StoredState
 from ops.model import Container, ModelError, Unit
 from ops.pebble import Layer, LayerDict
 
@@ -90,51 +87,21 @@ class WorkloadService:
 class PebbleService:
     """Pebble service abstraction running in a Juju unit."""
 
-    def __init__(self, unit: Unit, stored_state: StoredState) -> None:
+    def __init__(self, unit: Unit) -> None:
         self._unit = unit
         self._container = unit.get_container(WORKLOAD_SERVICE)
         self._layer_dict: LayerDict = PEBBLE_LAYER_DICT
-        self.stored = stored_state
-        self.stored.set_default(
-            config_hash=None,
-        )
 
-    @property
-    def current_config_hash(self) -> Optional[int]:
-        return self.stored.config_hash
+    def plan(self, layer: Layer, config_file: ConfigFile) -> None:
+        self._container.add_layer(WORKLOAD_SERVICE, layer, combine=True)
 
-    def prepare_dir(self, path: str | PurePath) -> None:
-        if self._container.isdir(path):
-            return
-
-        self._container.make_dir(path=path, make_parents=True)
-
-    def update_config_file(self, content: "ConfigFile") -> bool:
-        """Update the config file.
-
-        Return True if the config changed.
-        """
-        config_hash = hash(content)
-        if config_hash == self.current_config_hash:
-            return False
-
-        self._container.push(CONFIG_FILE_NAME, str(content), make_dirs=True)
-        self.stored.config_hash = config_hash
-        return True
-
-    def _restart_service(self, restart: bool = False) -> None:
-        if restart:
-            self._container.restart(WORKLOAD_CONTAINER)
-        elif not self._container.get_service(WORKLOAD_CONTAINER).is_running():
-            self._container.start(WORKLOAD_CONTAINER)
-        else:
-            self._container.replan()
-
-    def plan(self, layer: Layer, restart: bool = True) -> None:
-        self._container.add_layer(WORKLOAD_CONTAINER, layer, combine=True)
-
+        current_config_file = ConfigFile.from_workload_container(self._container)
         try:
-            self._restart_service(restart)
+            if config_file != current_config_file:
+                self._container.push(CONFIG_FILE_NAME, config_file.content, make_dirs=True)
+                self._container.restart(WORKLOAD_SERVICE)
+            else:
+                self._container.replan()
         except Exception as e:
             raise PebbleServiceError(f"Pebble failed to restart the workload service. Error: {e}")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,11 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 from typing import Generator
 from unittest.mock import MagicMock, PropertyMock, create_autospec
 
 import pytest
-from ops import BoundStoredState, Container, EventBase, Unit
+from ops import Container, EventBase, Unit
 from ops.testing import Harness
 from pytest_mock import MockerFixture
 from yarl import URL
@@ -40,13 +40,6 @@ def mocked_k8s_resource_patch(mocker: MockerFixture) -> None:
 @pytest.fixture
 def mocked_container() -> MagicMock:
     return create_autospec(Container)
-
-
-@pytest.fixture
-def mocked_stored_state() -> MagicMock:
-    m = create_autospec(BoundStoredState)
-    m.config_hash = None
-    return m
 
 
 @pytest.fixture

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from ops import ModelError
+from pytest_mock import MockerFixture
 
+from configs import ConfigFile
 from constants import (
     ADMIN_PORT,
     CONFIG_FILE_NAME,
@@ -89,78 +91,69 @@ class TestWorkloadService:
 
 class TestPebbleService:
     @pytest.fixture
-    def pebble_service(
-        self, mocked_unit: MagicMock, mocked_stored_state: MagicMock
-    ) -> PebbleService:
-        return PebbleService(mocked_unit, mocked_stored_state)
+    def pebble_service(self, mocked_unit: MagicMock) -> PebbleService:
+        return PebbleService(mocked_unit)
 
-    def test_update_config_file(
-        self, mocked_container: MagicMock, pebble_service: PebbleService
+    @pytest.fixture
+    def mocked_config_file(self, mocker: MockerFixture) -> MagicMock:
+        mocked = mocker.patch("charm.ConfigFile.from_workload_container")
+        mocked.return_value = ConfigFile("config_file")
+        return mocked
+
+    @patch("ops.pebble.Layer")
+    def test_plan_when_config_files_mismatch(
+        self,
+        mocked_layer: MagicMock,
+        mocked_config_file: MagicMock,
+        mocked_container: MagicMock,
+        pebble_service: PebbleService,
     ) -> None:
-        config_file_content = "config"
-        changed = pebble_service.update_config_file(config_file_content)
+        pebble_service.plan(mocked_layer, config_file=ConfigFile("new_config_file"))
 
-        assert changed is True
+        mocked_container.add_layer.assert_called_once_with(
+            WORKLOAD_SERVICE, mocked_layer, combine=True
+        )
         mocked_container.push.assert_called_once_with(
-            CONFIG_FILE_NAME, config_file_content, make_dirs=True
-        )
-
-    def test_update_config_file_without_change(
-        self, mocked_container: MagicMock, pebble_service: PebbleService
-    ) -> None:
-        config_file_content = "config"
-        pebble_service.stored.config_hash = hash(config_file_content)
-
-        changed = pebble_service.update_config_file(config_file_content)
-
-        assert changed is False
-        mocked_container.push.assert_not_called()
-
-    @patch("ops.pebble.Layer")
-    def test_plan_without_restart(
-        self,
-        mocked_layer: MagicMock,
-        mocked_container: MagicMock,
-        pebble_service: PebbleService,
-    ) -> None:
-        pebble_service.plan(mocked_layer, restart=False)
-
-        mocked_container.add_layer.assert_called_once_with(
-            WORKLOAD_CONTAINER, mocked_layer, combine=True
-        )
-        mocked_container.replan.assert_called_once()
-
-    @patch("ops.pebble.Layer")
-    def test_plan_with_restart(
-        self,
-        mocked_layer: MagicMock,
-        mocked_container: MagicMock,
-        pebble_service: PebbleService,
-    ) -> None:
-        pebble_service.plan(mocked_layer)
-
-        mocked_container.add_layer.assert_called_once_with(
-            WORKLOAD_CONTAINER, mocked_layer, combine=True
+            CONFIG_FILE_NAME, "new_config_file", make_dirs=True
         )
         mocked_container.restart.assert_called_once()
+        mocked_container.replan.assert_not_called()
+
+    @patch("ops.pebble.Layer")
+    def test_plan_when_config_files_match(
+        self,
+        mocked_layer: MagicMock,
+        mocked_config_file: MagicMock,
+        mocked_container: MagicMock,
+        pebble_service: PebbleService,
+    ) -> None:
+        pebble_service.plan(mocked_layer, config_file=ConfigFile("config_file"))
+
+        mocked_container.add_layer.assert_called_once_with(
+            WORKLOAD_SERVICE, mocked_layer, combine=True
+        )
+        mocked_container.push.assert_not_called()
+        mocked_container.restart.assert_not_called()
+        mocked_container.replan.assert_called_once()
 
     @patch("ops.pebble.Layer")
     def test_plan_failure(
         self,
         mocked_layer: MagicMock,
+        mocked_config_file: MagicMock,
         mocked_container: MagicMock,
         pebble_service: PebbleService,
     ) -> None:
         with (
-            patch.object(mocked_container, "restart", side_effect=Exception) as restart,
+            patch.object(mocked_container, "replan", side_effect=Exception) as replan,
             pytest.raises(PebbleServiceError),
         ):
-            pebble_service.plan(mocked_layer)
+            pebble_service.plan(mocked_layer, config_file=ConfigFile("config_file"))
 
         mocked_container.add_layer.assert_called_once_with(
-            WORKLOAD_CONTAINER, mocked_layer, combine=True
+            WORKLOAD_SERVICE, mocked_layer, combine=True
         )
-        restart.assert_called_once()
+        replan.assert_called_once()
 
     def test_render_pebble_layer(self, pebble_service: PebbleService) -> None:
         data_source = MagicMock(spec=EnvVarConvertible)


### PR DESCRIPTION
This pull request aims to fix the https://github.com/canonical/hydra-operator/issues/422.