### PR TITLE
test: autouse pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 pythonpath = ["src", "lib", "tests"]
+asyncio_mode = "auto"
 
 # Linting and formatting tools configuration
 [tool.codespell]


### PR DESCRIPTION
this avoids the event loop closed errors when running the integration tests

Read more here: https://pytest-asyncio.readthedocs.io/en/stable/concepts.html#auto-mode

The alternative would be to mark all the fixtures and tests, but that's only necessary if we need to use other asyncio libaries.