### PR TITLE
feat: key-values with quotes & commas in metadata

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -167,7 +167,7 @@ actions:
         description: A list of contacts for the client
         type: array
       metadata:
-        description: A comma-separated string of <key>=<value> with extra information relevant for the client, eg dept=IT
+        description: A space-separated string of <key>=<value> with extra information relevant for the client, eg "dept=IT team=alpha". Keys and values containing spaces should be quoted.
         type: string
       audience:
         description: A list with the allowed audience for the client

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -321,7 +321,7 @@ class TestUpdateOAuthClientAction:
                 "redirect-uris": ["https://example.ory.com"],
                 "contacts": ["test@canonical.com", "me@me.com"],
                 "client-uri": "https://example.com",
-                "metadata": "foo=bar,bar=foo",
+                "metadata": "foo=bar bar=foo",
                 "name": "test-client",
             },
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,9 +6,62 @@ from unittest.mock import MagicMock, patch
 import pytest
 from ops.pebble import Error, ExecError
 
-from cli import CommandLine
+from cli import CommandLine, parse_kv_string
 from constants import CONFIG_FILE_NAME
 from exceptions import MigrationError
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        # Simple single key-value pair
+        ("foo=bar", {"foo": "bar"}),
+        # Multiple key-value pairs
+        ("foo=bar baz=qux", {"foo": "bar", "baz": "qux"}),
+        # Single quoted value with space
+        ("foo='bar qux' baz=quux", {"foo": "bar qux", "baz": "quux"}),
+        # Multiple single quoted values with spaces
+        ("foo='bar qux' baz='quux quuz'", {"foo": "bar qux", "baz": "quux quuz"}),
+        # Single quoted value containing equals sign
+        ("foo='bar=qux' baz=quux", {"foo": "bar=qux", "baz": "quux"}),
+        # Mix of unquoted and quoted values
+        (
+            "foo=bar baz='qux quux' corge='grault garply'",
+            {"foo": "bar", "baz": "qux quux", "corge": "grault garply"},
+        ),
+        # Key without value (implicit empty string)
+        ("foo=bar baz=qux quux=", {"foo": "bar", "baz": "qux", "quux": ""}),
+        # Explicit empty value
+        ("foo=bar baz=", {"foo": "bar", "baz": ""}),
+        # Mix of single and double quotes
+        ("foo='bar' baz=\"qux\"", {"foo": "bar", "baz": "qux"}),
+        # # Unquoted value containing equals sign
+        # ("foo=bar=baz", {"foo": "bar=baz"}),
+        # All values single quoted with spaces
+        (
+            "foo='bar qux' baz='quux quuz' corge='grault garply'",
+            {"foo": "bar qux", "baz": "quux quuz", "corge": "grault garply"},
+        ),
+        # Empty quoted values
+        ("foo='' bar=\"\"", {"foo": "", "bar": ""}),
+        # Escaped double quote in value
+        ('foo=bar baz="q\\"ux"', {"foo": "bar", "baz": 'q"ux'}),
+        # Leading and trailing spaces in quoted value
+        ("foo='  bar  ' baz=\"  qux  \"", {"foo": "  bar  ", "baz": "  qux  "}),
+        # Special characters in quoted values
+        ("foo='bar,qux' baz='quux;quuz'", {"foo": "bar,qux", "baz": "quux;quuz"}),
+        # Undefined (due to increased complexity):
+        # Multiple equals signs in unquoted value
+        # "foo=bar=baz"
+    ],
+)
+def test_key_value_parser(input_str: str, expected: dict[str, str]) -> None:
+    assert parse_kv_string(input_str) == expected
+
+
+def test_key_value_parser_missing_equals() -> None:
+    with pytest.raises(ValueError):
+        parse_kv_string("foobar")
 
 
 class TestCommandLine:


### PR DESCRIPTION
**Note: This is a breaking change.**

This changes the input format for metadata to space-delimited tokens. This allows us to piggy-back on `shlex` to do the parsing, and ensures we properly handle escape sequences and other edge cases we might otherwise miss.

This is a bit of a compromise between comma delimited key-values, and using a more complex format like json.