### PR TITLE
fix: fix the run-migration action to check container connectivity

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -661,8 +661,8 @@ class HydraCharm(CharmBase):
         event.add_status(ActiveStatus())
 
     def _on_run_migration(self, event: ActionEvent) -> None:
-        if not self._workload_service.is_running:
-            event.fail("Service is not ready. Please re-run the action when the charm is active")
+        if not container_connectivity(self):
+            event.fail("Container is not connected yet")
             return
 
         if not peer_integration_exists(self):

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -9,6 +9,7 @@ from ops.testing import ActionFailed, Harness
 from pytest_mock import MockerFixture
 
 from cli import OAuthClient
+from constants import WORKLOAD_CONTAINER
 from exceptions import MigrationError
 from integrations import DatabaseConfig
 
@@ -26,21 +27,18 @@ class TestRunMigrationAction:
     def mocked_cli(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("charm.CommandLine.migrate")
 
-    def test_when_hydra_service_not_ready(
+    def test_when_container_not_connected(
         self,
         harness: Harness,
-        mocked_workload_service: MagicMock,
         mocked_cli: MagicMock,
         peer_integration: int,
     ) -> None:
-        mocked_workload_service.is_running = False
+        harness.set_can_connect(WORKLOAD_CONTAINER, False)
+
         try:
             harness.run_action("run-migration")
         except ActionFailed as err:
-            assert (
-                "Service is not ready. Please re-run the action when the charm is active"
-                in err.message
-            )
+            assert "Container is not connected yet" in err.message
 
         mocked_cli.assert_not_called()
 


### PR DESCRIPTION
This pull request aims to resolve https://github.com/canonical/hydra-operator/issues/460.