### PR TITLE
test: ensure the container used for pebble-ready is in the state

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -63,7 +63,7 @@ class TestPebbleReadyEvent:
         mocked_holistic_handler: MagicMock,
     ) -> None:
         """Test the successful handling of the Pebble Ready event."""
-        state = create_state()
+        state = create_state(containers={container})
 
         state_out = context.run(context.on.pebble_ready(container), state)
 


### PR DESCRIPTION
When running a pebble-ready event, the testing.State needs to contain the same testing.Container that's passed to create the (mock) event. This PR makes that change.

Scenario currently has a bug meaning that this isn't checked, but that will be fixed in https://github.com/canonical/operator/pull/2570