### PR TITLE
feat: support 26.04 base

### DIFF
--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -16,4 +16,4 @@ jobs:
     uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@1bf335af1d939c8543e53d376dd49d79126c2cd3 # v1.15.0
     with:
       container-name: "hydra"
-      use-charmcraftcache: true
+      use-charmcraftcache: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,7 @@ jobs:
     with:
       destination_channel: ${{ inputs.destination_channel}}
       source_branch: ${{ inputs.source_branch}}
-      use-charmcraftcache: true
+      use-charmcraftcache: false
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS}}
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -312,6 +312,3 @@ parts:
     source: .
     build-snaps:
       - astral-uv
-    build-packages:
-      - "rustc-1.85"
-      - "cargo-1.85"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -300,6 +300,8 @@ actions:
 platforms:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
 
 parts:
   templates:


### PR DESCRIPTION
- adds support for 26.04 base
- disable charmcraftcache in all workflows
- remove rustc and cargo dependencies from `charmcraft.yaml` since they are no longer required with uv