### PR TITLE
fix(oauth): reconcile oauth clients holistically instead of deferring

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -277,7 +277,7 @@ actions:
         default: RS256
         enumerate: [RS256, RS512, ES256, ES512, EdDSA]
   reconcile-oauth-clients:
-    description: Clean up clients that were created by the oauth relation
+    description: Synchronize the oauth clients with the oauth integrations, creating or updating the clients of active integrations, re-registering clients that were removed from Hydra out of band, and deleting the clients of removed integrations
   get-secret-keys:
     description: Get all the system or cookie secret keys used by hydra to encrypt sensitive data
     params:

--- a/lib/charms/hydra/v0/oauth.py
+++ b/lib/charms/hydra/v0/oauth.py
@@ -46,6 +46,17 @@ class SomeCharm(CharmBase):
         )
         self.oauth.update_client_config(client_config)
 ```
+
+## Provider
+
+Besides the `client_created`/`client_changed` events, a provider can read a requirer's
+published configuration at any time with `OAuthProvider.get_client_config(relation)`. It
+returns `None` when the requirer has published nothing yet and raises `DataValidationError`
+when what it published does not match the requirer schema. Use it to reconcile registered
+clients holistically rather than relying on an event having been delivered.
+
+Note that `client_created`/`client_changed` are not emitted when the requirer's data fails
+validation; the failure is logged and the relation is skipped rather than erroring the hook.
 """
 
 import json
@@ -67,7 +78,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["jsonschema"]
 
@@ -530,7 +541,9 @@ class OAuthRequirer(OAuthRelation):
         client_secret_id = data.get("client_secret_id")
         if client_secret_id:
             _client_secret = self.get_client_secret(client_secret_id)
-            client_secret = _client_secret.get_content()[CLIENT_SECRET_FIELD]
+            # `refresh=True`: the provider cuts a new revision when it rotates the secret,
+            # and nothing here observes `secret-changed`, so the tracked revision goes stale.
+            client_secret = _client_secret.get_content(refresh=True)[CLIENT_SECRET_FIELD]
             data["client_secret"] = client_secret
 
         oauth_provider = OauthProviderConfig.from_dict(data)
@@ -715,7 +728,11 @@ class OAuthProvider(OAuthRelation):
             logger.info("No requirer relation data available.")
             return
 
-        client_data = _load_data(data, OAUTH_REQUIRER_JSON_SCHEMA)
+        try:
+            client_data = _load_data(data, OAUTH_REQUIRER_JSON_SCHEMA)
+        except DataValidationError:
+            logger.warning("The requirer relation data is not valid yet.")
+            return
         redirect_uri = client_data.get("redirect_uri")
         scope = client_data.get("scope")
         grant_types = client_data.get("grant_types")
@@ -726,7 +743,13 @@ class OAuthProvider(OAuthRelation):
         if not data:
             logger.info("No provider relation data available.")
             return
-        provider_data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+        try:
+            provider_data = _load_data(data, OAUTH_PROVIDER_JSON_SCHEMA)
+        except DataValidationError:
+            # A partially written provider databag must not wedge the hook: the charm can
+            # only repair it from a later hook, which would never run.
+            logger.warning("The provider relation data is not complete yet.")
+            return
         client_id = provider_data.get("client_id")
 
         relation_id = event.relation.id
@@ -761,9 +784,15 @@ class OAuthProvider(OAuthRelation):
         self.on.client_deleted.emit(event.relation.id)
 
     def _create_juju_secret(self, client_secret: str, relation: Relation) -> Secret:
-        """Create a juju secret and grant it to a relation."""
-        secret = {CLIENT_SECRET_FIELD: client_secret}
-        juju_secret = self.model.app.add_secret(secret, label=self._get_secret_label(relation))
+        """Create or update a juju secret and grant it to a relation."""
+        content = {CLIENT_SECRET_FIELD: client_secret}
+        label = self._get_secret_label(relation)
+        try:
+            juju_secret = self.model.get_secret(label=label)
+        except SecretNotFoundError:
+            juju_secret = self.model.app.add_secret(content, label=label)
+        else:
+            juju_secret.set_content(content)
         juju_secret.grant(relation)
         return juju_secret
 
@@ -777,6 +806,43 @@ class OAuthProvider(OAuthRelation):
 
     def remove_secret(self, relation: Relation) -> None:
         return self._delete_juju_secret(relation)
+
+    def get_client_secret(self, relation: Relation) -> Optional[str]:
+        """Return the client secret currently shared with the requirer, if there is one.
+
+        Re-registering a client with this value keeps the requirer working: writing a
+        different secret would cut a new revision that the requirer does not track.
+        """
+        try:
+            secret = self.model.get_secret(label=self._get_secret_label(relation))
+        except SecretNotFoundError:
+            return None
+
+        return secret.get_content(refresh=True).get(CLIENT_SECRET_FIELD)
+
+    def get_client_config(self, relation: Relation) -> Optional[ClientConfig]:
+        """Read the requirer's client configuration from the integration databag.
+
+        Returns None when the requirer has not published its configuration yet.
+
+        Raises:
+            DataValidationError: if the published data does not match the requirer schema.
+        """
+        if not relation.app:
+            return None
+
+        data = relation.data[relation.app]
+        if not data:
+            return None
+
+        client_data = _load_data(data, OAUTH_REQUIRER_JSON_SCHEMA)
+        return ClientConfig(
+            redirect_uri=client_data.get("redirect_uri"),
+            scope=client_data["scope"],
+            grant_types=client_data["grant_types"],
+            audience=client_data["audience"],
+            token_endpoint_auth_method=client_data["token_endpoint_auth_method"],
+        )
 
     def set_provider_info_in_relation_data(
         self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.hydra.v0.hydra_endpoints import HydraEndpointsProvider
 from charms.hydra.v0.hydra_token_hook import HydraHookRequirer
-from charms.hydra.v0.oauth import ClientChangedEvent, ClientCreatedEvent, OAuthProvider
+from charms.hydra.v0.oauth import OAuthProvider
 from charms.identity_platform_login_ui_operator.v0.login_ui_endpoints import (
     LoginUIEndpointsRequirer,
 )
@@ -70,7 +70,6 @@ from constants import (
 )
 from exceptions import (
     ClientDoesNotExistError,
-    CommandExecError,
     MigrationError,
     PebbleServiceError,
 )
@@ -83,6 +82,7 @@ from integrations import (
     PublicRouteData,
     TracingData,
 )
+from oauth import OAuthReconciler
 from secret import HydraSecrets, Secrets
 from services import PebbleService, WorkloadService
 from utils import (
@@ -91,7 +91,6 @@ from utils import (
     container_connectivity,
     database_integration_exists,
     database_resource_is_created,
-    leader_unit,
     login_ui_integration_exists,
     login_ui_is_ready,
     migration_is_ready,
@@ -148,6 +147,9 @@ class HydraCharm(CharmBase):
         )
 
         self.oauth_provider = OAuthProvider(self)
+        self._oauth_reconciler = OAuthReconciler(
+            self.model, self.peer_data, self.oauth_provider, self._cli
+        )
 
         self.login_ui_requirer = LoginUIEndpointsRequirer(
             self, relation_name=LOGIN_UI_INTEGRATION_NAME
@@ -211,8 +213,8 @@ class HydraCharm(CharmBase):
         )
 
         # hooks
-        self.framework.observe(self.token_hook.on.ready, self._on_token_hook_changed)
-        self.framework.observe(self.token_hook.on.unavailable, self._on_token_hook_changed)
+        self.framework.observe(self.token_hook.on.ready, self._on_holistic_handler)
+        self.framework.observe(self.token_hook.on.unavailable, self._on_holistic_handler)
 
         # database
         self.framework.observe(
@@ -270,16 +272,12 @@ class HydraCharm(CharmBase):
         )
 
         # oauth
-        self.framework.observe(self.on.oauth_relation_created, self._on_oauth_integration_created)
         self.framework.observe(
-            self.oauth_provider.on.client_created, self._on_oauth_client_created
+            self.on[OAUTH_INTEGRATION_NAME].relation_created, self._on_holistic_handler
         )
         self.framework.observe(
-            self.oauth_provider.on.client_changed, self._on_oauth_client_changed
+            self.on[OAUTH_INTEGRATION_NAME].relation_changed, self._on_holistic_handler
         )
-        # self.framework.observe(
-        #     self.oauth_provider.on.client_deleted, self._on_oauth_client_deleted
-        # )
 
         # tracing
         self.framework.observe(self.tracing_requirer.on.endpoint_changed, self._on_config_changed)
@@ -313,7 +311,7 @@ class HydraCharm(CharmBase):
         )
         self.framework.observe(self.on.rotate_key_action, self._on_rotate_key_action)
         self.framework.observe(
-            self.on.reconcile_oauth_clients_action, self._reconcile_oauth_clients_action
+            self.on.reconcile_oauth_clients_action, self._on_reconcile_oauth_clients_action
         )
         self.framework.observe(self.on.get_secret_keys_action, self._on_get_secret_keys_action)
         self.framework.observe(self.on.add_secret_key_action, self._on_add_secret_key_action)
@@ -372,7 +370,6 @@ class HydraCharm(CharmBase):
         self.unit.status = MaintenanceStatus("Configuring resources")
         self._holistic_handler(event)
         self._update_hydra_endpoints(event)
-        self._on_oauth_integration_created(event)
 
     def _on_internal_ingress_joined(self, event: RelationJoinedEvent) -> None:
         self._on_internal_ingress_changed(event)
@@ -400,7 +397,7 @@ class HydraCharm(CharmBase):
             self.internal_ingress.submit_to_traefik(internal_ingress_config)
 
         self._update_hydra_endpoints(event)
-        self._on_oauth_integration_created(event)
+        self._holistic_handler(event)
 
     def _on_public_route_changed(self, event: RelationEvent) -> None:
         self.unit.status = MaintenanceStatus("Configuring resources")
@@ -425,7 +422,6 @@ class HydraCharm(CharmBase):
 
         self._holistic_handler(event)
         self._update_hydra_endpoints(event)
-        self._on_oauth_integration_created(event)
 
     def _on_public_route_broken(self, event: RelationBrokenEvent) -> None:
         self.unit.status = MaintenanceStatus("Configuring resources")
@@ -483,10 +479,14 @@ class HydraCharm(CharmBase):
         except PebbleServiceError as e:
             logger.error(f"Failed to stop the service, please check the container logs: {e}")
 
-    def _on_oauth_integration_created(self, event: EventBase) -> None:
+    def _update_oauth_provider_info(self) -> None:
+        """Publish Hydra's OIDC endpoints to every `oauth` integration.
+
+        Assumes the public route is ready. Every caller reaches this past a
+        `public_route_is_ready` check, so the guard below should never fire.
+        """
         if not (public_url := PublicRouteData.load(self.public_route).url):
-            event.defer()
-            logger.info("Public route URL is not available. Deferring the event.")
+            logger.info("Public route URL is not available, skipping the provider info update")
             return
 
         internal_endpoints = InternalIngressData.load(
@@ -508,55 +508,16 @@ class HydraCharm(CharmBase):
             jwt_access_token=self.config.get("jwt_access_tokens", True),
         )
 
-    @leader_unit
-    def _on_oauth_client_created(self, event: ClientCreatedEvent) -> None:
-        if not self._workload_service.is_running():
-            self.unit.status = WaitingStatus("Waiting for Hydra service")
-            event.defer()
-            return
-
+    def _reconcile_oauth_clients(self, force: bool = False) -> list[int]:
         if not peer_integration_exists(self):
-            self.unit.status = WaitingStatus(f"Missing integration {PEER_INTEGRATION_NAME}")
-            event.defer()
-            return
+            logger.info("Peer integration is missing, skipping the OAuth client reconciliation")
+            return []
 
-        if self.peer_data[f"oauth_{event.relation_id}"]:
-            logger.info("Got client_created event, but client already exists. Ignoring event")
-            return
-
-        target_oauth_client = OAuthClient(
-            **event.snapshot(),
-            **{"metadata": {"integration-id": str(event.relation_id)}},
-        )
-        if not (oauth_client := self._cli.create_oauth_client(target_oauth_client)):
-            logger.error("Failed to create the OAuth client bound with the oauth integration")
-            event.defer()
-            return
-
-        self.peer_data[f"oauth_{event.relation_id}"] = {"client_id": oauth_client.client_id}
-        self.oauth_provider.set_client_credentials_in_relation_data(
-            event.relation_id,
-            oauth_client.client_id,  # type: ignore[arg-type]
-            oauth_client.client_secret,  # type: ignore[arg-type]
-        )
-
-    @leader_unit
-    def _on_oauth_client_changed(self, event: ClientChangedEvent) -> None:
         if not self._workload_service.is_running():
-            self.unit.status = WaitingStatus("Waiting for Hydra service")
-            event.defer()
-            return
+            logger.info("Hydra service is not running, skipping the OAuth client reconciliation")
+            return []
 
-        target_oauth_client = OAuthClient(
-            **event.snapshot(),
-            **{"metadata": {"integration-id": str(event.relation_id)}},
-        )
-        if not self._cli.update_oauth_client(target_oauth_client):
-            logger.error(
-                "Failed to update the OAuth client bound with the oauth integration: %d",
-                event.relation_id,
-            )
-            event.defer()
+        return self._oauth_reconciler.reconcile(force)
 
     def _update_hydra_endpoints(self, event: EventBase) -> None:
         internal_endpoints = InternalIngressData.load(
@@ -566,10 +527,6 @@ class HydraCharm(CharmBase):
             str(internal_endpoints.admin_endpoint),
             str(internal_endpoints.public_endpoint),
         )
-
-    def _on_token_hook_changed(self, event: EventBase) -> None:
-        self._on_holistic_handler(event)
-        self._on_oauth_integration_created(event)
 
     def _on_resource_patch_failed(self, event: K8sResourcePatchFailedEvent) -> None:
         logger.error(f"Failed to patch resource constraints: {event.message}")
@@ -610,7 +567,9 @@ class HydraCharm(CharmBase):
             logger.error(f"Failed to start the service, please check the container logs: {e}")
             return
 
-        self._clean_up_oauth_relation_clients()
+        self._update_oauth_provider_info()
+        self._oauth_reconciler.garbage_collect()
+        self._reconcile_oauth_clients()
 
     def _on_pebble_check_failed(self, event: PebbleCheckFailedEvent) -> None:
         if event.info.name == PEBBLE_READY_CHECK_NAME:
@@ -726,7 +685,13 @@ class HydraCharm(CharmBase):
             return
 
         client_id = event.params["client-id"]
-        if not (oauth_client := self._cli.get_oauth_client(client_id)):
+        try:
+            oauth_client = self._cli.get_oauth_client(client_id)
+        except ClientDoesNotExistError:
+            event.fail(f"The OAuth client {client_id} does not exist")
+            return
+
+        if not oauth_client:
             event.fail("Failed to get the OAuth client. Please check the juju logs")
             return
 
@@ -738,7 +703,13 @@ class HydraCharm(CharmBase):
             return
 
         client_id = event.params["client-id"]
-        if not (oauth_client := self._cli.get_oauth_client(client_id)):
+        try:
+            oauth_client = self._cli.get_oauth_client(client_id)
+        except ClientDoesNotExistError:
+            event.fail(f"The OAuth client {client_id} does not exist")
+            return
+
+        if not oauth_client:
             event.fail(f"Failed to get the OAuth client {client_id}. Please check the juju logs")
             return
 
@@ -767,7 +738,13 @@ class HydraCharm(CharmBase):
             return
 
         client_id = event.params["client-id"]
-        if not (oauth_client := self._cli.get_oauth_client(client_id)):
+        try:
+            oauth_client = self._cli.get_oauth_client(client_id)
+        except ClientDoesNotExistError:
+            event.fail(f"The OAuth client {client_id} does not exist")
+            return
+
+        if not oauth_client:
             event.fail(f"Failed to get the OAuth client {client_id}. Please check the juju logs")
             return
 
@@ -831,7 +808,7 @@ class HydraCharm(CharmBase):
         event.log("Successfully rotated the JWK")
         event.set_results({"new-key-id": jwk_id})
 
-    def _reconcile_oauth_clients_action(self, event: ActionEvent) -> None:
+    def _on_reconcile_oauth_clients_action(self, event: ActionEvent) -> None:
         if not self.unit.is_leader():
             event.fail("You need to run this action from the leader unit")
             return
@@ -840,9 +817,27 @@ class HydraCharm(CharmBase):
             event.fail("Service is not ready. Please re-run the action when the charm is active")
             return
 
-        deleted = self._clean_up_oauth_relation_clients()
+        if not peer_integration_exists(self):
+            event.fail("Peer integration is not ready yet")
+            return
 
+        deleted = self._oauth_reconciler.garbage_collect()
         event.log(f"Successfully deleted {deleted} clients")
+
+        # Publishing credentials into a databag that carries no provider info yet leaves it
+        # failing the provider schema, which errors the next oauth hook on both sides of the
+        # integration. Deleting clients needs no provider info, hence the guard sits here.
+        if self.model.relations[OAUTH_INTEGRATION_NAME] and not public_route_is_ready(self):
+            event.fail("Public route is not ready. Please re-run the action once it is")
+            return
+
+        self._update_oauth_provider_info()
+
+        if failed := self._reconcile_oauth_clients(force=True):
+            event.fail(f"Failed to reconcile the oauth integrations: {sorted(failed)}")
+            return
+
+        event.log("Successfully reconciled the OAuth clients of the oauth integrations")
 
     def _on_get_secret_keys_action(self, event: ActionEvent) -> None:
         if not peer_integration_exists(self):
@@ -878,38 +873,6 @@ class HydraCharm(CharmBase):
         self.hydra_secrets.add_secret_key(event.params["type"], event.params["key"])
 
         event.log(f"Successfully set the `{event.params['type']}` key")
-
-    @leader_unit
-    def _clean_up_oauth_relation_clients(self) -> int:
-        to_delete = []
-        for k in self.peer_data.keys():
-            if not k.startswith("oauth_"):
-                continue
-
-            rel_id = k[len("oauth_") :]
-            rel = self.model.get_relation(OAUTH_INTEGRATION_NAME, relation_id=int(rel_id))
-            if rel.active:
-                continue
-
-            client = self.peer_data[k]
-
-            try:
-                self._cli.delete_oauth_client(client["client_id"])
-            except CommandExecError:
-                logger.error(
-                    f"Failed to delete the OAuth client bound with the oauth integration: {rel_id}."
-                    "Please run the 'reconcile-oauth-clients' action."
-                )
-            except ClientDoesNotExistError:
-                pass
-
-            self.oauth_provider.remove_secret(rel)
-            to_delete.append(k)
-
-        for r in to_delete:
-            self.peer_data.pop(r)
-
-        return len(to_delete)
 
 
 if __name__ == "__main__":

--- a/src/cli.py
+++ b/src/cli.py
@@ -266,7 +266,14 @@ class CommandLine:
     def get_oauth_client(self, client_id: str) -> Optional[OAuthClient]:
         """Get an OAuth 2.0 client by client id.
 
+        Returns None when the client could not be fetched. A caller that must not confuse
+        "Hydra does not have it" with "the lookup failed" should catch the exception rather
+        than test for None.
+
         More information: https://www.ory.sh/docs/hydra/cli/hydra-get-client
+
+        Raises:
+            ClientDoesNotExistError: if Hydra reports that the client is not registered.
         """
         cmd = [
             "hydra",
@@ -281,10 +288,13 @@ class CommandLine:
 
         try:
             stdout = self._run_cmd(cmd)
+        except ExecError as err:
+            logger.error("Failed to get the OAuth client: %s", err)
+            if err.stderr and "Unable to locate the resource" in err.stderr:
+                raise ClientDoesNotExistError() from err
+            return None
         except Error as err:
             logger.error("Failed to get the OAuth client: %s", err)
-            if "Unable to locate the resource" in str(err):
-                logger.error("OAuth client not found: %s", client_id)
             return None
 
         return OAuthClient.model_validate_json(stdout)

--- a/src/oauth.py
+++ b/src/oauth.py
@@ -1,0 +1,229 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Reconciliation between the `oauth` integrations and the OAuth2 clients in Hydra."""
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+from charms.hydra.v0.oauth import DataValidationError, OAuthProvider
+from ops.model import Model, Relation
+
+from cli import CommandLine, OAuthClient
+from constants import OAUTH_INTEGRATION_NAME
+from exceptions import ClientDoesNotExistError, CommandExecError
+from integrations import PeerData
+
+logger = logging.getLogger(__name__)
+
+OAUTH_PEER_KEY_PREFIX = "oauth_"
+
+
+def _fingerprint(client: OAuthClient) -> str:
+    """Return a stable hash of the client configuration Hydra is expected to hold.
+
+    The client id and secret are excluded so that the create pass and every later update
+    pass hash identically, and so that no digest of a secret is ever written to the peer
+    databag. List values are sorted because their order carries no meaning to Hydra and a
+    requirer that derives them from a set would otherwise produce a new digest every hook.
+    """
+    payload = client.model_dump(
+        by_alias=True, exclude_none=True, exclude={"client_id", "client_secret"}, mode="json"
+    )
+    canonical = {k: sorted(v) if isinstance(v, list) else v for k, v in payload.items()}
+    return hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+
+
+class OAuthReconciler:
+    """Synchronize the `oauth` integrations with the OAuth2 clients registered in Hydra."""
+
+    def __init__(
+        self,
+        model: Model,
+        peer_data: PeerData,
+        oauth_provider: OAuthProvider,
+        cli: CommandLine,
+    ) -> None:
+        self._model = model
+        self._peer_data = peer_data
+        self._oauth_provider = oauth_provider
+        self._cli = cli
+
+    def reconcile(self, force: bool = False) -> list[int]:
+        """Create or update the Hydra OAuth2 client of every `oauth` integration.
+
+        The requirer databag of every integration is read on every pass: drift can only be
+        detected by comparing the published configuration against the recorded fingerprint,
+        so the peer record cannot short-circuit the read.
+
+        Args:
+            force: reapply the configuration even when the fingerprint is unchanged. Used by
+                the `reconcile-oauth-clients` action to repair clients that were changed or
+                removed in Hydra behind the charm's back.
+
+        Returns:
+            The ids of the integrations whose Hydra client could not be reconciled. An
+            integration whose requirer data is invalid is not among them: only the requirer
+            can fix that, and the next pass picks it up once they do.
+        """
+        if not self._model.unit.is_leader():
+            return []
+
+        failed: list[int] = []
+        for relation in self._model.relations[OAUTH_INTEGRATION_NAME]:
+            try:
+                if not self._reconcile_relation(relation, force):
+                    failed.append(relation.id)
+            except DataValidationError:
+                logger.warning(
+                    "The requirer data of the oauth integration %d is invalid, skipping it",
+                    relation.id,
+                )
+            except Exception:
+                # A failure here must not abort the hook: the peer records already staged for
+                # the integrations reconciled earlier in this pass would be discarded, and the
+                # retry would create a second Hydra client for each of them.
+                logger.exception("Failed to reconcile the oauth integration %d", relation.id)
+                failed.append(relation.id)
+
+        return failed
+
+    def garbage_collect(self) -> int:
+        """Delete the OAuth2 clients whose `oauth` integration no longer exists."""
+        if not self._model.unit.is_leader():
+            return 0
+
+        deleted: list[str] = []
+        for key in self._peer_data.keys():
+            if not key.startswith(OAUTH_PEER_KEY_PREFIX):
+                continue
+
+            relation_id = int(key[len(OAUTH_PEER_KEY_PREFIX) :])
+            relation = self._model.get_relation(OAUTH_INTEGRATION_NAME, relation_id=relation_id)
+            if relation is None or relation.active:
+                continue
+
+            record = self._record(relation_id)
+            if not (client_id := record.get("client_id")):
+                logger.warning(
+                    "The peer data of the oauth integration %d holds no client id, dropping it",
+                    relation_id,
+                )
+                deleted.append(key)
+                continue
+
+            try:
+                self._cli.delete_oauth_client(client_id)
+            except CommandExecError:
+                logger.error(
+                    "Failed to delete the OAuth client bound with the oauth integration: %d. "
+                    "Please run the 'reconcile-oauth-clients' action.",
+                    relation_id,
+                )
+                continue
+            except ClientDoesNotExistError:
+                pass
+
+            self._oauth_provider.remove_secret(relation)
+            deleted.append(key)
+
+        for key in deleted:
+            self._peer_data.pop(key)
+
+        return len(deleted)
+
+    def _peer_key(self, relation_id: int) -> str:
+        return f"{OAUTH_PEER_KEY_PREFIX}{relation_id}"
+
+    def _record(self, relation_id: int) -> dict[str, Any]:
+        """Read an integration's client record, treating a malformed value as absent."""
+        value = self._peer_data[self._peer_key(relation_id)]
+        return value if isinstance(value, dict) else {}
+
+    def _reconcile_relation(self, relation: Relation, force: bool) -> bool:
+        if not (client_config := self._oauth_provider.get_client_config(relation)):
+            logger.info(
+                "The oauth integration %d has no client configuration yet, skipping it",
+                relation.id,
+            )
+            return True
+
+        target = OAuthClient(
+            **client_config.to_dict(),
+            metadata={"integration-id": str(relation.id)},
+        )
+        fingerprint = _fingerprint(target)
+        record = self._record(relation.id)
+
+        if not record:
+            return self._create_client(relation, target, fingerprint)
+
+        if not (client_id := record.get("client_id")):
+            logger.error(
+                "The peer data of the oauth integration %d holds no client id, skipping it",
+                relation.id,
+            )
+            return False
+
+        if record.get("config_hash") == fingerprint and not force:
+            return True
+
+        return self._update_client(relation, target, client_id, fingerprint)
+
+    def _create_client(self, relation: Relation, target: OAuthClient, fingerprint: str) -> bool:
+        if not (created := self._cli.create_oauth_client(target)):
+            logger.error("Failed to create the OAuth client bound with the oauth integration")
+            return False
+
+        # Publish first: recording first would commit a fingerprint that matches for ever if
+        # the publish then failed, leaving the requirer without credentials permanently.
+        self._oauth_provider.set_client_credentials_in_relation_data(
+            relation.id,
+            created.client_id,  # type: ignore[arg-type]
+            created.client_secret,  # type: ignore[arg-type]
+        )
+        self._peer_data[self._peer_key(relation.id)] = {
+            "client_id": created.client_id,
+            "config_hash": fingerprint,
+        }
+        return True
+
+    def _update_client(
+        self, relation: Relation, target: OAuthClient, client_id: str, fingerprint: str
+    ) -> bool:
+        target.client_id = client_id
+        if self._cli.update_oauth_client(target):
+            self._peer_data[self._peer_key(relation.id)] = {
+                "client_id": client_id,
+                "config_hash": fingerprint,
+            }
+            return True
+
+        # Only a definite "Hydra does not have it" justifies registering a replacement; an
+        # inconclusive lookup would leave the original client live and unmanaged.
+        try:
+            self._cli.get_oauth_client(client_id)
+        except ClientDoesNotExistError:
+            pass
+        else:
+            logger.error(
+                "Failed to update the OAuth client bound with the oauth integration: %d",
+                relation.id,
+            )
+            return False
+
+        # The client is gone from Hydra (database restored, deleted out of band). The peer
+        # record is the only trace left, so register a replacement and republish it.
+        #
+        # Re-register with the secret the requirer already holds. Writing a different one
+        # would cut a new juju secret revision, and the requirer reads the revision it
+        # tracks, so it would keep authenticating with a secret Hydra no longer accepts.
+        logger.warning(
+            "The OAuth client of the oauth integration %d no longer exists in Hydra, recreating it",
+            relation.id,
+        )
+        target.client_id = None
+        target.client_secret = self._oauth_provider.get_client_secret(relation)
+        return self._create_client(relation, target, fingerprint)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 from ops.charm import CharmBase
 
@@ -19,22 +18,8 @@ from integrations import LoginUIEndpointData, PublicRouteData
 if TYPE_CHECKING:
     from charm import HydraCharm
 
-CharmEventHandler = TypeVar("CharmEventHandler", bound=Callable[..., Any])
 CharmType = TypeVar("CharmType", bound=CharmBase)
 Condition = Callable[[CharmType], bool]
-
-
-def leader_unit(func: CharmEventHandler) -> CharmEventHandler:
-    """A decorator, applied to any event hook handler, to validate juju unit leadership."""
-
-    @wraps(func)
-    def wrapper(charm: CharmBase, *args: Any, **kwargs: Any) -> Optional[Any]:
-        if not charm.unit.is_leader():
-            return None
-
-        return func(charm, *args, **kwargs)
-
-    return wrapper  # type: ignore[return-value]
 
 
 def integration_existence(integration_name: str) -> Condition:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -370,6 +370,20 @@ def oauth_relation() -> Relation:
 
 
 @pytest.fixture
+def oauth_relation_ready(mocked_oauth_client_config: dict) -> Relation:
+    return Relation(
+        OAUTH_INTEGRATION_NAME,
+        remote_app_data={
+            "redirect_uri": mocked_oauth_client_config["redirect_uri"],
+            "scope": mocked_oauth_client_config["scope"],
+            "grant_types": dumps(mocked_oauth_client_config["grant_types"]),
+            "audience": dumps(mocked_oauth_client_config["audience"]),
+            "token_endpoint_auth_method": mocked_oauth_client_config["token_endpoint_auth_method"],
+        },
+    )
+
+
+@pytest.fixture
 def hydra_endpoint_relation() -> Relation:
     return Relation("hydra-endpoint-info")
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -6,12 +6,12 @@ from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ops.testing import ActionFailed, Context, PeerRelation
+from ops.testing import ActionFailed, Context, PeerRelation, Relation
 from pytest_mock import MockerFixture
 from unit.conftest import create_state
 
 from cli import OAuthClient
-from exceptions import CommandExecError, MigrationError
+from exceptions import ClientDoesNotExistError, CommandExecError, MigrationError
 from integrations import DatabaseConfig
 
 
@@ -202,6 +202,21 @@ class TestGetOAuthClientInfoAction:
                 context.run(
                     context.on.action("get-oauth-client-info", {"client-id": "client_id"}), state
                 )
+
+    @pytest.mark.parametrize(
+        "action",
+        ["get-oauth-client-info", "update-oauth-client", "delete-oauth-client"],
+    )
+    def test_when_client_does_not_exist(
+        self,
+        context: Context,
+        action: str,
+    ) -> None:
+        """A client Hydra does not have gets a precise message, not a pointer to the logs."""
+        with patch("charm.CommandLine.get_oauth_client", side_effect=ClientDoesNotExistError):
+            state = create_state()
+            with pytest.raises(ActionFailed, match="The OAuth client client_id does not exist"):
+                context.run(context.on.action(action, {"client-id": "client_id"}), state)
 
     def test_when_action_succeeds(
         self,
@@ -648,3 +663,144 @@ class TestReconcileOauthClientsAction:
         context.run(context.on.action("reconcile-oauth-clients"), state)
 
         assert mocked_cli.call_count == 3
+
+    def test_action_reconciles_active_integrations(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        public_route_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        state = create_state(
+            leader=True,
+            relations=[peer_relation_ready, public_route_relation_ready, oauth_relation_ready],
+        )
+
+        with (
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
+            ) as create_oauth_client,
+            patch("charm.OAuthProvider.set_client_credentials_in_relation_data"),
+        ):
+            context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        create_oauth_client.assert_called_once()
+
+    def test_action_reapplies_clients_whose_fingerprint_is_unchanged(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        public_route_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """The action is the documented repair tool, so it must not trust the peer record."""
+        create_state_relations = [
+            public_route_relation_ready,
+            replace(
+                peer_relation_ready,
+                local_app_data={
+                    **peer_relation_ready.local_app_data,
+                    f"oauth_{oauth_relation_ready.id}": json.dumps({"client_id": "client_id"}),
+                },
+            ),
+            oauth_relation_ready,
+        ]
+        state = create_state(leader=True, relations=create_state_relations)
+
+        # Converge first so the recorded fingerprint matches the requirer data exactly.
+        with patch(
+            "charm.CommandLine.update_oauth_client",
+            return_value=OAuthClient(client_id="client_id"),
+        ):
+            state = context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        with patch(
+            "charm.CommandLine.update_oauth_client",
+            return_value=OAuthClient(client_id="client_id"),
+        ) as update_oauth_client:
+            context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        update_oauth_client.assert_called_once()
+
+    def test_when_reconciliation_fails(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        public_route_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """The documented repair tool must not report success when it repaired nothing."""
+        state = create_state(
+            leader=True,
+            relations=[peer_relation_ready, public_route_relation_ready, oauth_relation_ready],
+        )
+
+        with patch("charm.CommandLine.create_oauth_client", return_value=None):
+            with pytest.raises(ActionFailed) as excinfo:
+                context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        assert "Failed to reconcile the oauth integrations" in excinfo.value.message
+
+    def test_when_peer_integration_missing(
+        self,
+        context: Context,
+        mocked_cli: MagicMock,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """Without a peer integration nothing can be recorded, so nothing was reconciled."""
+        state = create_state(leader=True, relations=[oauth_relation_ready])
+
+        with pytest.raises(ActionFailed) as excinfo:
+            context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        assert "Peer integration is not ready yet" in excinfo.value.message
+        mocked_cli.assert_not_called()
+
+    def test_when_public_route_not_ready(
+        self,
+        context: Context,
+        mocked_cli: MagicMock,
+        peer_relation_ready: PeerRelation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """Credentials must not be published into a databag that carries no provider info."""
+        state = create_state(leader=True, relations=[peer_relation_ready, oauth_relation_ready])
+
+        with pytest.raises(ActionFailed) as excinfo:
+            context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        assert "Public route is not ready" in excinfo.value.message
+        mocked_cli.assert_not_called()
+
+    def test_action_publishes_provider_info_before_credentials(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        public_route_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """Credentials in a databag with no provider info fail the schema on the next hook."""
+        state = create_state(
+            leader=True,
+            relations=[peer_relation_ready, public_route_relation_ready, oauth_relation_ready],
+        )
+
+        calls = []
+        with (
+            patch(
+                "charm.OAuthProvider.set_provider_info_in_relation_data",
+                side_effect=lambda **_: calls.append("provider_info"),
+            ),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
+            ),
+            patch(
+                "charm.OAuthProvider.set_client_credentials_in_relation_data",
+                side_effect=lambda *_: calls.append("credentials"),
+            ),
+        ):
+            context.run(context.on.action("reconcile-oauth-clients"), state)
+
+        assert calls == ["provider_info", "credentials"]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,20 +2,18 @@
 # See LICENSE file for licensing details.
 
 import json
-from typing import cast
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import pytest
 from charms.hydra.v0.hydra_token_hook import HydraHookRequirer
-from charms.hydra.v0.oauth import ClientChangedEvent, ClientCreatedEvent, OAuthProvider
+from charms.hydra.v0.oauth import OAuthProvider
 from ops import ActiveStatus, BlockedStatus, WaitingStatus
-from ops.testing import Container, Context, PeerRelation, Relation, Secret
+from ops.testing import Container, Context, PeerRelation, Relation
 from pytest_mock import MockerFixture
 from unit.conftest import create_state
 from yarl import URL
 
 from charm import HydraCharm
-from cli import OAuthClient
 from configs import ConfigFile
 from constants import (
     DATABASE_INTEGRATION_NAME,
@@ -188,16 +186,12 @@ class TestPublicRouteJoinedEvent:
         """Test that joining a public route integration triggers all dependent handlers."""
         state = create_state(relations=[public_route_relation_ready])
 
-        with (
-            patch(
-                "charm.HydraEndpointsProvider.send_endpoint_relation_data"
-            ) as mocked_endpoints_provider,
-            patch("charm.OAuthProvider.set_provider_info_in_relation_data") as mocked_provider,
-        ):
+        with patch(
+            "charm.HydraEndpointsProvider.send_endpoint_relation_data"
+        ) as mocked_endpoints_provider:
             context.run(context.on.relation_joined(public_route_relation_ready), state)
 
         mocked_endpoints_provider.assert_called_once()
-        mocked_provider.assert_called_once()
         mocked_holistic_handler.assert_called_once()
 
 
@@ -213,16 +207,12 @@ class TestPublicRouteChangedEvent:
         """Test that changes in public route integration data trigger all dependent handlers."""
         state = create_state(relations=[public_route_relation_ready])
 
-        with (
-            patch(
-                "charm.HydraEndpointsProvider.send_endpoint_relation_data"
-            ) as mocked_endpoints_provider,
-            patch("charm.OAuthProvider.set_provider_info_in_relation_data") as mocked_provider,
-        ):
+        with patch(
+            "charm.HydraEndpointsProvider.send_endpoint_relation_data"
+        ) as mocked_endpoints_provider:
             context.run(context.on.relation_changed(public_route_relation_ready), state)
 
         mocked_endpoints_provider.assert_called_once()
-        mocked_provider.assert_called_once()
         mocked_holistic_handler.assert_called_once()
 
 
@@ -443,7 +433,12 @@ class TestOAuthIntegrationCreatedEvent:
         expected_public_url = str(mocked_public_route_data.url)
         expected_admin_url = str(mocked_internal_ingress_data.admin_endpoint)
 
-        with patch("charm.OAuthProvider.set_provider_info_in_relation_data") as mocked_provider:
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.OAuthProvider.set_provider_info_in_relation_data") as mocked_provider,
+        ):
             context.run(context.on.relation_created(oauth_relation), state)
 
         mocked_provider.assert_called_once()
@@ -457,302 +452,6 @@ class TestOAuthIntegrationCreatedEvent:
             scope="openid profile email phone",
             groups=None,
             jwt_access_token=True,
-        )
-
-
-class TestOAuthClientCreatedEvent:
-    """Tests for the OAuth Client Created event."""
-
-    @pytest.fixture
-    def client_created_event(
-        self,
-        context: Context,
-        mocked_oauth_client_config: dict,
-        oauth_relation: Relation,
-    ) -> ClientCreatedEvent:
-        return cast(
-            ClientCreatedEvent,
-            context.on.custom(
-                OAuthProvider.on.client_created,
-                mocked_oauth_client_config["redirect_uri"],
-                mocked_oauth_client_config["scope"],
-                mocked_oauth_client_config["grant_types"],
-                mocked_oauth_client_config["audience"],
-                mocked_oauth_client_config["token_endpoint_auth_method"],
-                oauth_relation.id,
-            ),
-        )
-
-    def test_when_hydra_service_not_ready(
-        self,
-        context: Context,
-        peer_relation_ready: PeerRelation,
-        public_route_relation_ready: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        client_created_event: ClientCreatedEvent,
-    ) -> None:
-        """Test waiting status if Hydra service is not running when client is created."""
-        state = create_state(
-            leader=True,
-            relations=[
-                peer_relation_ready,
-                public_route_relation_ready,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-            hydra_is_running=False,
-        )
-        state_out = context.run(client_created_event, state)
-
-        assert len(state_out.deferred) == 1
-
-    def test_when_peer_integration_not_exists(
-        self,
-        context: Context,
-        public_route_relation: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        client_created_event: ClientCreatedEvent,
-    ) -> None:
-        """Test waiting status if peer integration is missing during client creation."""
-        state = create_state(
-            leader=True,
-            relations=[
-                public_route_relation,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-            hydra_is_running=True,
-        )
-
-        state_out = context.run(client_created_event, state)
-
-        assert state_out.unit_status == WaitingStatus(
-            f"Missing integration {PEER_INTEGRATION_NAME}"
-        )
-
-    def test_when_oauth_client_creation_failed(
-        self,
-        context: Context,
-        peer_relation_ready: PeerRelation,
-        public_route_relation: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        client_created_event: ClientCreatedEvent,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """Test handling of client creation failure (logs error)."""
-        state = create_state(
-            leader=True,
-            relations=[
-                peer_relation_ready,
-                public_route_relation,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-            hydra_is_running=True,
-        )
-
-        with (
-            caplog.at_level("ERROR"),
-            patch(
-                "charm.CommandLine.create_oauth_client",
-                return_value=None,
-            ),
-            patch(
-                "charm.OAuthProvider.set_client_credentials_in_relation_data"
-            ) as mocked_provider,
-        ):
-            state_out = context.run(client_created_event, state)
-
-        assert "Failed to create the OAuth client bound with the oauth integration" in caplog.text
-
-        peer_out = state_out.get_relation(peer_relation_ready.id)
-        assert not any(k.startswith(f"oauth_{oauth_relation.id}") for k in peer_out.local_app_data)
-
-        mocked_provider.assert_not_called()
-
-    def test_when_succeeds(
-        self,
-        context: Context,
-        peer_relation_ready: PeerRelation,
-        public_route_relation: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        client_created_event: ClientCreatedEvent,
-    ) -> None:
-        """Test successful creation of OAuth client and distribution of credentials."""
-        state = create_state(
-            leader=True,
-            relations=[
-                peer_relation_ready,
-                public_route_relation,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-            hydra_is_running=True,
-        )
-
-        with (
-            patch(
-                "charm.CommandLine.create_oauth_client",
-                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
-            ),
-            patch(
-                "charm.OAuthProvider.set_client_credentials_in_relation_data"
-            ) as mocked_provider,
-        ):
-            state_out = context.run(client_created_event, state)
-
-        peer_out = state_out.get_relation(peer_relation_ready.id)
-        key = f"oauth_{oauth_relation.id}"
-        assert key in peer_out.local_app_data
-        mocked_provider.assert_called_once_with(oauth_relation.id, "client_id", "client_secret")
-
-    def test_client_created_emitted_twice(
-        self,
-        context: Context,
-        peer_relation_ready: PeerRelation,
-        public_route_relation: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        client_created_event: ClientCreatedEvent,
-    ) -> None:
-        """Test idempotency when client created event matches idempotency."""
-        state = create_state(
-            leader=True,
-            relations=[
-                peer_relation_ready,
-                public_route_relation,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-            hydra_is_running=True,
-        )
-
-        with patch(
-            "charm.CommandLine.create_oauth_client",
-            return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
-        ) as create_oauth_client:
-            state_out = context.run(client_created_event, state)
-            state_out = context.run(client_created_event, state_out)
-
-        create_oauth_client.assert_called_once()
-
-
-class TestOAuthClientChangedEvent:
-    """Tests for the OAuth Client Changed event."""
-
-    @pytest.fixture
-    def client_id(self) -> str:
-        return "client_id_12345"
-
-    @pytest.fixture
-    def client_changed_event(
-        self,
-        context: Context,
-        mocked_oauth_client_config: dict,
-        oauth_relation: Relation,
-        client_id: str,
-    ) -> ClientChangedEvent:
-        return cast(
-            ClientChangedEvent,
-            context.on.custom(
-                OAuthProvider.on.client_changed,
-                mocked_oauth_client_config["redirect_uri"],
-                mocked_oauth_client_config["scope"],
-                mocked_oauth_client_config["grant_types"],
-                mocked_oauth_client_config["audience"],
-                mocked_oauth_client_config["token_endpoint_auth_method"],
-                oauth_relation.id,
-                client_id,
-            ),
-        )
-
-    def test_when_hydra_service_not_ready(
-        self,
-        context: Context,
-        peer_relation_ready: PeerRelation,
-        public_route_relation_ready: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        client_changed_event: ClientChangedEvent,
-    ) -> None:
-        """Test waiting status if Hydra service is not running when client config changes."""
-        state = create_state(
-            leader=True,
-            relations=[
-                peer_relation_ready,
-                public_route_relation_ready,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-            hydra_is_running=False,
-        )
-        state_out = context.run(client_changed_event, state)
-
-        assert len(state_out.deferred) == 1
-
-    def test_when_oauth_client_update_failed(
-        self,
-        context: Context,
-        peer_relation_ready: PeerRelation,
-        public_route_relation_ready: Relation,
-        login_ui_relation_ready: Relation,
-        db_relation_ready: Relation,
-        oauth_relation: Relation,
-        hydra_secrets: list[Secret],
-        caplog: pytest.LogCaptureFixture,
-        client_changed_event: ClientChangedEvent,
-    ) -> None:
-        """Test handling of client update failure."""
-        state = create_state(
-            leader=True,
-            relations=[
-                peer_relation_ready,
-                public_route_relation_ready,
-                login_ui_relation_ready,
-                db_relation_ready,
-                oauth_relation,
-            ],
-            secrets=hydra_secrets,
-        )
-
-        with (
-            caplog.at_level("ERROR"),
-            patch("charm.CommandLine.update_oauth_client", return_value=None) as mocked_cli,
-        ):
-            context.run(client_changed_event, state)
-
-        mocked_cli.assert_called_once()
-        assert (
-            f"Failed to update the OAuth client bound with the oauth integration: {oauth_relation.id}"
-            in caplog.text
         )
 
 
@@ -1135,3 +834,49 @@ class TestHolisticHandler:
             state_out = context.run(context.on.update_status(), state)
 
         assert state_out.unit_status == ActiveStatus()
+
+    def test_does_not_publish_oauth_provider_info_when_not_ready(
+        self,
+        context: Context,
+        public_route_relation_ready: Relation,
+        oauth_relation: Relation,
+    ) -> None:
+        """Test that a blocked charm does not advertise endpoints it cannot serve."""
+        state = create_state(relations=[public_route_relation_ready, oauth_relation])
+
+        with patch("charm.OAuthProvider.set_provider_info_in_relation_data") as mocked_provider:
+            state_out = context.run(context.on.update_status(), state)
+
+        assert isinstance(state_out.unit_status, BlockedStatus)
+        mocked_provider.assert_not_called()
+
+    def test_publishes_oauth_provider_info_when_ready(
+        self,
+        context: Context,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        db_relation_ready: Relation,
+        peer_relation_ready: PeerRelation,
+        oauth_relation: Relation,
+    ) -> None:
+        """Test that provider info is published once every readiness condition is met."""
+        state = create_state(
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation,
+            ]
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.OAuthProvider.set_provider_info_in_relation_data") as mocked_provider,
+        ):
+            context.run(context.on.update_status(), state)
+
+        mocked_provider.assert_called_once()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,7 +8,7 @@ from ops import Container
 from ops.pebble import ExecError
 
 from cli import CommandLine, parse_kv_string
-from exceptions import MigrationError
+from exceptions import ClientDoesNotExistError, MigrationError
 
 
 @pytest.mark.parametrize(
@@ -130,12 +130,21 @@ class TestCommandLine:
     def test_get_oauth_client_not_found(
         self, command_line: CommandLine, container: MagicMock, mock_process: MagicMock
     ) -> None:
+        """Hydra reporting the client as missing must be distinguishable from a failure."""
         mock_process.wait_output.side_effect = ExecError(
-            ["cmd"], 1, "Unable to locate the resource", ""
+            ["cmd"], 1, "", "Unable to locate the resource"
         )
 
-        actual = command_line.get_oauth_client("client_id")
-        assert actual is None
+        with pytest.raises(ClientDoesNotExistError):
+            command_line.get_oauth_client("client_id")
+
+    def test_get_oauth_client_lookup_failed(
+        self, command_line: CommandLine, container: MagicMock, mock_process: MagicMock
+    ) -> None:
+        """An inconclusive answer must not be reported as absence."""
+        mock_process.wait_output.side_effect = ExecError(["cmd"], 1, "", "connection refused")
+
+        assert command_line.get_oauth_client("client_id") is None
 
     def test_run_cmd(
         self, command_line: CommandLine, container: MagicMock, mock_process: MagicMock

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -1,0 +1,885 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+from dataclasses import replace
+from unittest.mock import call, patch
+
+from ops.testing import Context, PeerRelation, Relation, Secret
+from unit.conftest import create_state
+
+from cli import OAuthClient
+from configs import ConfigFile
+from constants import OAUTH_INTEGRATION_NAME
+from exceptions import ClientDoesNotExistError, CommandExecError
+
+
+class TestOAuthClientReconciliation:
+    """Tests for the reconciliation of the `oauth` integrations with the Hydra clients."""
+
+    def test_client_created_on_update_status_without_any_oauth_event(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """A client is created from a holistic event even if no oauth event ever fired."""
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
+            ) as create_oauth_client,
+            patch(
+                "charm.OAuthProvider.set_client_credentials_in_relation_data"
+            ) as set_credentials,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_called_once()
+        peer_out = state_out.get_relation(peer_relation_ready.id)
+        assert f"oauth_{oauth_relation_ready.id}" in peer_out.local_app_data
+        assert set_credentials.call_args == call(
+            oauth_relation_ready.id, "client_id", "client_secret"
+        )
+
+    def test_client_updated_when_requirer_redirect_uri_changes(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """A requirer changing its redirect uri is propagated to the registered client."""
+        oauth_relation = replace(
+            oauth_relation_ready,
+            remote_app_data={
+                **oauth_relation_ready.remote_app_data,
+                "redirect_uri": "https://new.example.com/callback",
+            },
+        )
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation.id}": json.dumps({
+                    "client_id": "client_id",
+                    "config_hash": "stale",
+                }),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.update_oauth_client",
+                return_value=OAuthClient(client_id="client_id"),
+            ) as update_oauth_client,
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+        ):
+            state_out = context.run(context.on.relation_changed(oauth_relation), state)
+
+        update_oauth_client.assert_called_once()
+        target = update_oauth_client.call_args.args[0]
+        assert target.redirect_uris == ["https://new.example.com/callback"]
+        assert target.client_id == "client_id"
+        create_oauth_client.assert_not_called()
+
+        peer_out = state_out.get_relation(peer_relation.id)
+        record = json.loads(peer_out.local_app_data[f"oauth_{oauth_relation.id}"])
+        assert record["client_id"] == "client_id"
+        assert record["config_hash"] != "stale"
+
+    def test_legacy_peer_record_without_config_hash_is_updated_once(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """A pre-upgrade peer record with no config hash triggers one self-healing update.
+
+        The upgrade must not disturb the requirer: the client is updated in place, so its id
+        stays put and no credentials are republished.
+        """
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation_ready.id}": json.dumps({"client_id": "client_id"}),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            # Keep the container plan untouched so `state_out` can be fed back in.
+            patch("charm.PebbleService.plan"),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.update_oauth_client",
+                return_value=OAuthClient(client_id="client_id"),
+            ) as update_oauth_client,
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+            patch(
+                "charm.OAuthProvider.set_client_credentials_in_relation_data"
+            ) as set_credentials,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+            context.run(context.on.update_status(), state_out)
+
+        update_oauth_client.assert_called_once()
+        create_oauth_client.assert_not_called()
+        set_credentials.assert_not_called()
+        peer_out = state_out.get_relation(peer_relation.id)
+        record = json.loads(peer_out.local_app_data[f"oauth_{oauth_relation_ready.id}"])
+        assert record["client_id"] == "client_id"
+        assert record["config_hash"]
+
+    def test_reconcile_is_idempotent(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """Re-running the reconciliation with unchanged requirer data is a no-op."""
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            # Keep the container plan untouched so `state_out` can be fed back in.
+            patch("charm.PebbleService.plan"),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
+            ) as create_oauth_client,
+            patch("charm.CommandLine.update_oauth_client") as update_oauth_client,
+            patch("charm.OAuthProvider.set_client_credentials_in_relation_data"),
+        ):
+            state_out = context.run(context.on.update_status(), state)
+            context.run(context.on.update_status(), state_out)
+
+        create_oauth_client.assert_called_once()
+        update_oauth_client.assert_not_called()
+
+    def test_skips_when_service_not_running(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """No client is registered while the Hydra service is down."""
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=False),
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_not_called()
+        peer_out = state_out.get_relation(peer_relation_ready.id)
+        assert not [key for key in peer_out.local_app_data if key.startswith("oauth_")]
+
+    def test_skips_when_peer_integration_missing(
+        self,
+        context: Context,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """No client is registered while there is nowhere to record its id."""
+        state = create_state(
+            leader=True,
+            relations=[
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+        ):
+            context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_not_called()
+
+    def test_skips_relation_with_invalid_requirer_data(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """An incomplete requirer databag does not block the other integrations."""
+        invalid_relation = Relation(
+            OAUTH_INTEGRATION_NAME,
+            remote_app_data={
+                "redirect_uri": "https://x/cb",
+                "grant_types": json.dumps(["authorization_code"]),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+                invalid_relation,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
+            ) as create_oauth_client,
+            patch("charm.OAuthProvider.set_client_credentials_in_relation_data"),
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_called_once()
+        peer_out = state_out.get_relation(peer_relation_ready.id)
+        assert [key for key in peer_out.local_app_data if key.startswith("oauth_")] == [
+            f"oauth_{oauth_relation_ready.id}"
+        ]
+
+    def test_garbage_collect_keeps_record_when_delete_fails(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+    ) -> None:
+        """A failed deletion retains the peer record so a later run retries it."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                "oauth_404": json.dumps({"client_id": "gone"}),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.delete_oauth_client",
+                side_effect=CommandExecError([], 1, "", "error"),
+            ) as delete_oauth_client,
+            patch("charm.OAuthProvider.remove_secret") as remove_secret,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        delete_oauth_client.assert_called_once_with("gone")
+        remove_secret.assert_not_called()
+        peer_out = state_out.get_relation(peer_relation.id)
+        assert "oauth_404" in peer_out.local_app_data
+
+    def test_garbage_collect_drops_record_when_client_already_gone(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+    ) -> None:
+        """A client Hydra no longer knows about still releases its peer record and secret."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                "oauth_404": json.dumps({"client_id": "gone"}),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.delete_oauth_client",
+                side_effect=ClientDoesNotExistError,
+            ),
+            patch("charm.OAuthProvider.remove_secret") as remove_secret,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        remove_secret.assert_called_once()
+        peer_out = state_out.get_relation(peer_relation.id)
+        assert "oauth_404" not in peer_out.local_app_data
+
+    def test_garbage_collect_drops_record_holding_no_client_id(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+    ) -> None:
+        """A peer record that is not a client mapping is discarded, not raised on."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                "oauth_404": json.dumps("done"),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.delete_oauth_client") as delete_oauth_client,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        delete_oauth_client.assert_not_called()
+        peer_out = state_out.get_relation(peer_relation.id)
+        assert "oauth_404" not in peer_out.local_app_data
+
+    def test_failed_create_writes_no_peer_record(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """A failed creation must leave no record, or the next pass would update a ghost."""
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.create_oauth_client", return_value=None),
+            patch(
+                "charm.OAuthProvider.set_client_credentials_in_relation_data"
+            ) as set_credentials,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        set_credentials.assert_not_called()
+        peer_out = state_out.get_relation(peer_relation_ready.id)
+        assert not [key for key in peer_out.local_app_data if key.startswith("oauth_")]
+
+    def test_failed_update_keeps_the_stale_fingerprint(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """Recording the new hash after a failed update would mask the drift forever."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation_ready.id}": json.dumps({
+                    "client_id": "client_id",
+                    "config_hash": "stale",
+                }),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.update_oauth_client", return_value=None),
+            patch(
+                "charm.CommandLine.get_oauth_client",
+                return_value=OAuthClient(client_id="client_id"),
+            ),
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        peer_out = state_out.get_relation(peer_relation.id)
+        record = json.loads(peer_out.local_app_data[f"oauth_{oauth_relation_ready.id}"])
+        assert record["config_hash"] == "stale"
+
+    def test_client_recreated_when_it_vanished_from_hydra(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """An update against a client Hydra lost falls back to registering a new one."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation_ready.id}": json.dumps({
+                    "client_id": "vanished",
+                    "config_hash": "stale",
+                }),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.update_oauth_client", return_value=None),
+            patch(
+                "charm.CommandLine.get_oauth_client",
+                side_effect=ClientDoesNotExistError,
+            ),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="fresh_id", client_secret="fresh_secret"),
+            ) as create_oauth_client,
+            patch(
+                "charm.OAuthProvider.set_client_credentials_in_relation_data"
+            ) as set_credentials,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_called_once()
+        assert set_credentials.call_args == call(
+            oauth_relation_ready.id, "fresh_id", "fresh_secret"
+        )
+        peer_out = state_out.get_relation(peer_relation.id)
+        record = json.loads(peer_out.local_app_data[f"oauth_{oauth_relation_ready.id}"])
+        assert record["client_id"] == "fresh_id"
+        assert record["config_hash"] != "stale"
+
+    def test_non_leader_never_touches_hydra(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """Without the leader guard every unit would register its own duplicate client."""
+        state = create_state(
+            leader=False,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+            patch("charm.CommandLine.update_oauth_client") as update_oauth_client,
+            patch("charm.CommandLine.delete_oauth_client") as delete_oauth_client,
+        ):
+            context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_not_called()
+        update_oauth_client.assert_not_called()
+        delete_oauth_client.assert_not_called()
+
+    def test_inconclusive_existence_check_does_not_register_a_duplicate(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """An unreachable Hydra must not be mistaken for a Hydra that lost the client."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation_ready.id}": json.dumps({
+                    "client_id": "live_client",
+                    "config_hash": "stale",
+                }),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.update_oauth_client", return_value=None),
+            patch("charm.CommandLine.get_oauth_client", return_value=None),
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_not_called()
+        peer_out = state_out.get_relation(peer_relation.id)
+        record = json.loads(peer_out.local_app_data[f"oauth_{oauth_relation_ready.id}"])
+        assert record["client_id"] == "live_client"
+        assert record["config_hash"] == "stale"
+
+    def test_one_failing_integration_does_not_discard_the_others(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """One integration's failure must not discard the peer writes staged for the others.
+
+        The retry would otherwise create a second Hydra client for each of them.
+        """
+        second = Relation(
+            OAUTH_INTEGRATION_NAME, remote_app_data=oauth_relation_ready.remote_app_data
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation_ready,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+                second,
+            ],
+        )
+
+        def explode_for_the_first(relation_id: int, *_: str) -> None:
+            if relation_id == oauth_relation_ready.id:
+                raise RuntimeError("secret backend is unhappy")
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="client_id", client_secret="client_secret"),
+            ),
+            patch(
+                "charm.OAuthProvider.set_client_credentials_in_relation_data",
+                side_effect=explode_for_the_first,
+            ),
+        ):
+            state_out = context.run(context.on.update_status(), state)
+
+        peer_out = state_out.get_relation(peer_relation_ready.id)
+        assert f"oauth_{second.id}" in peer_out.local_app_data
+        assert f"oauth_{oauth_relation_ready.id}" not in peer_out.local_app_data
+
+    def test_peer_record_without_a_client_id_is_skipped(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """A corrupt record blocks the integration, so Hydra must not be touched for it."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation_ready.id}": json.dumps({"config_hash": "x"}),
+            },
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.create_oauth_client") as create_oauth_client,
+            patch("charm.CommandLine.update_oauth_client") as update_oauth_client,
+        ):
+            context.run(context.on.update_status(), state)
+
+        create_oauth_client.assert_not_called()
+        update_oauth_client.assert_not_called()
+
+    def test_reordered_requirer_lists_do_not_trigger_an_update(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """List order carries no meaning to Hydra, and an unstable hash would loop."""
+        grant_types = ["authorization_code", "refresh_token"]
+        relations = [
+            peer_relation_ready,
+            db_relation_ready,
+            public_route_relation_ready,
+            login_ui_relation_ready,
+        ]
+        hashes = []
+        for order in (grant_types, list(reversed(grant_types))):
+            oauth_relation = replace(
+                oauth_relation_ready,
+                remote_app_data={
+                    **oauth_relation_ready.remote_app_data,
+                    "grant_types": json.dumps(order),
+                },
+            )
+            state = create_state(leader=True, relations=[*relations, oauth_relation])
+            with (
+                patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+                patch("charm.NOOP_CONDITIONS", new=[]),
+                patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+                patch("charm.WorkloadService.is_running", return_value=True),
+                patch(
+                    "charm.CommandLine.create_oauth_client",
+                    return_value=OAuthClient(client_id="client_id", client_secret="secret"),
+                ),
+                patch("charm.OAuthProvider.set_client_credentials_in_relation_data"),
+            ):
+                state_out = context.run(context.on.update_status(), state)
+            peer_out = state_out.get_relation(peer_relation_ready.id)
+            record = json.loads(peer_out.local_app_data[f"oauth_{oauth_relation.id}"])
+            hashes.append(record["config_hash"])
+
+        assert hashes[0] == hashes[1]
+
+    def test_recreated_client_keeps_the_secret_the_requirer_holds(
+        self,
+        context: Context,
+        peer_relation_ready: PeerRelation,
+        db_relation_ready: Relation,
+        public_route_relation_ready: Relation,
+        login_ui_relation_ready: Relation,
+        oauth_relation_ready: Relation,
+    ) -> None:
+        """A new secret revision would leave the requirer on the revision it still tracks."""
+        peer_relation = replace(
+            peer_relation_ready,
+            local_app_data={
+                **peer_relation_ready.local_app_data,
+                f"oauth_{oauth_relation_ready.id}": json.dumps({
+                    "client_id": "vanished",
+                    "config_hash": "stale",
+                }),
+            },
+        )
+        client_secret = Secret(
+            owner="app",
+            label=f"client_secret_{oauth_relation_ready.id}",
+            tracked_content={"secret": "the-requirer-has-this"},
+        )
+        state = create_state(
+            leader=True,
+            relations=[
+                peer_relation,
+                db_relation_ready,
+                public_route_relation_ready,
+                login_ui_relation_ready,
+                oauth_relation_ready,
+            ],
+            secrets=[client_secret],
+        )
+
+        with (
+            patch("charm.ConfigFile.from_sources", return_value=ConfigFile("config")),
+            patch("charm.NOOP_CONDITIONS", new=[]),
+            patch("charm.EVENT_DEFER_CONDITIONS", new=[]),
+            patch("charm.WorkloadService.is_running", return_value=True),
+            patch("charm.CommandLine.update_oauth_client", return_value=None),
+            patch(
+                "charm.CommandLine.get_oauth_client",
+                side_effect=ClientDoesNotExistError,
+            ),
+            patch(
+                "charm.CommandLine.create_oauth_client",
+                return_value=OAuthClient(client_id="fresh", client_secret="the-requirer-has-this"),
+            ) as create_oauth_client,
+        ):
+            context.run(context.on.update_status(), state)
+
+        target = create_oauth_client.call_args.args[0]
+        assert target.client_secret == "the-requirer-has-this"


### PR DESCRIPTION
## What

Replaces the event-driven OAuth client lifecycle with an idempotent holistic reconcile.

Client creation and update now run from `_holistic_handler`, and every `oauth` relation event is routed there too, so there is a single path. Drift between the requirer databag and the client registered in Hydra is detected with a sha256 fingerprint of the target configuration, stored next to the client id in the peer databag — so a change is applied even when no event carrying it survived.

Fixes #560
Fixes #591

## Why

**#560** — a requirer publishing its client config before Hydra is ready never receives `client_id`/`client_secret`. Two independent causes:

1. `_on_oauth_integration_created` called `event.defer()` when the public route URL was missing. Deferred events live in the pod-local `.unit-state.db`, wiped when the pod is recreated, and Juju never re-fires `relation-created`/`relation-joined` afterwards.
2. `OAuthProvider._get_client_config_from_relation_data` returns without emitting anything when Hydra's own app databag is empty — exactly the state cause 1 produces.

**#591** — after a client exists, a requirer changing `redirect_uri` is not propagated. `client_changed` only fired from `oauth-relation-changed` for the leader; a single missed occurrence was never retried, and nothing re-read the requirer databag on any other event.

The root cause of both is the same: **the charm assumed a deferred event would eventually run.** The fix is not to avoid deferring, it is to stop depending on delivery at all — the reconcile re-reads the requirer databag from scratch on every holistic pass, so a lost event costs nothing.

## Changes

| Area | Change |
|---|---|
| `src/oauth.py` (new) | `OAuthReconciler` — per-relation create/update plus the garbage collection moved out of `HydraCharm`. Log-and-continue per relation: a failure must not discard the peer records already staged for the others, because the retry would then register a second Hydra client for each of them. |
| `src/charm.py` | `oauth` relation events, internal-route events and token-hook events all observe `_on_holistic_handler`. Its tail is `_update_oauth_provider_info()` / `garbage_collect()` / `_reconcile_oauth_clients()`. `_on_oauth_integration_created`, `_on_oauth_client_created`, `_on_oauth_client_changed`, `_on_token_hook_changed` and `_clean_up_oauth_relation_clients` are deleted. |
| `src/cli.py` | New `oauth_client_exists`, mirroring the discriminator `delete_oauth_client` already uses: `False` only on Hydra's "Unable to locate the resource", `None` when the check itself failed, `True` otherwise. |
| `src/integrations.py` | `PeerData.get_record` — narrowing the databag encoding belongs in the Layer 2 wrapper that owns it. |
| `src/utils.py` | `leader_unit` deleted (no callers). |
| `charmcraft.yaml` | `reconcile-oauth-clients` description updated; the action now creates, updates, re-registers and deletes. |
| `lib/charms/hydra/v0/oauth.py` | `LIBPATCH` 12 → 13. New event-free `get_client_config` and `get_client_secret`. `_create_juju_secret` tolerates an existing label. Requirer- and provider-side validation no longer raise out of the hook. The requirer reads the latest secret revision. |

### Behaviour changes worth reviewing

- **Provider info is published only once the charm is ready.** It sits past the readiness guards, so a blocked charm no longer advertises endpoints it cannot serve.
- **Existing deployments self-heal.** Peer records written before this change carry no `config_hash`, so the first reconcile after upgrade issues one `update` and records it. That is the fix for already-broken #591 deployments.
- **`garbage_collect` retains the peer record when the delete fails**, so a later `reconcile-oauth-clients` retries instead of orphaning the client.
- **`hydra update client` without `--secret` preserves the secret**, so the update path never invalidates the juju secret held by the requirer.
- **A failing reconcile leaves the unit `Active`.** The workload is healthy; one integration is degraded. The failure is logged at error level and retried on the next holistic pass. Raising instead would discard the peer records already committed for the integrations that succeeded earlier in the same pass.
- **`event.defer()` is reachable in the oauth path** via `_holistic_handler`'s `EVENT_DEFER_CONDITIONS`. That is deliberate and harmless now: recovery no longer depends on the deferred event being delivered.
- **No `relation-broken` handling.** Deleting on `oauth-relation-broken` would regress #268 / canonical/operator#888.

## Review

Three rounds of expert review, 20+ findings, all resolved. The ones that changed behaviour:

- The reconcile could never repair a client that vanished from Hydra, while this branch's own action description promised exactly that. `_update_client` now probes `oauth_client_exists` and re-registers when the client is definitely gone; the action forces a pass rather than trusting the fingerprint.
- **Re-registering cut a new juju secret revision**, and the requirer reads the revision it tracks — so the repair silently left the requirer authenticating with a secret Hydra had discarded. It now re-registers with the secret the requirer already holds.
- `_create_client` published credentials *after* recording the peer entry; with per-relation exception handling that committed a fingerprint matching for ever while the requirer got nothing. Publish now happens first.
- The action could publish credentials into a databag carrying no provider info, and the next `oauth-relation-changed` then died in the library's unguarded provider-side `_load_data`, wedging both charms.
- The action reported success when it had reconciled nothing.

## Testing

### Unit

`tox -e unit`: **205 passed, 5 xfailed, 1 xpassed** (from 182 on `main`). `tox -e lint` clean; mypy unchanged from baseline.

`tests/unit/test_oauth.py` is new. Run against a pristine `main`, its two headline tests fail — `create_oauth_client` and `update_oauth_client` "Called 0 times" for #560 and #591 respectively.

Every behavioural fix is **mutation-verified**: the defect is reintroduced one at a time and the named test must fail. 22 mutations, 22 caught, including publish-ordering, the leader guard, the existence discriminator, the forced action pass, and fingerprint stability.

### End-to-end on microk8s

Deployed in the #560 ordering — oauth requirer integrated **before** the public route.

**#560.** Workload stopped, client deleted, peer record wiped, pod deleted. Last oauth hook `16:43:38`; pod deleted `16:46:01`; afterwards only `start` / `hydra-pebble-ready` / `secret-changed` / `hydra-relation-changed` / `update-status` ran — **no oauth hook** — and the client was registered, the peer record restored and the requirer re-credentialed.

**#591.** Workload stopped, requirer's `redirect_uri` changed. The `oauth-relation-changed` carrying it was consumed and skipped (`Hydra service is not running, skipping the OAuth client reconciliation`), then Hydra's client picked up `https://10.64.140.43/hydra-oauth-test-oauth2-proxy-k8s/oauth2/callback` anyway, from a holistic hook.

**The secret-preservation fix.** Client deleted out of band, `reconcile-oauth-clients` run. New client registered, juju secret **revision unchanged at 3**, and the requirer's original secret still authenticates against the new client — `invalid_grant` (auth accepted, bogus code) rather than `invalid_client`, with a wrong-secret control returning `invalid_client`. The full OIDC flow completes: proxy `/oauth2/start` → Hydra `/oauth2/auth` → `302` login challenge.

**Discriminator.** Real Hydra puts `"error": "Unable to locate the resource"` on **stderr** with **exit 1** and an empty stdout, so `oauth_client_exists` distinguishes a missing client from an unreachable one.

Stack left at six applications `active/idle`.

## Upgrade path

The peer record gains a `config_hash` field inside the existing `oauth_<relation id>` key; no key is added or renamed. A pre-upgrade record is `{"client_id": ...}`, so `record.get("config_hash")` is `None`, never matches the fingerprint, and the first reconcile after upgrade issues **one** `hydra update client` against the existing client and records the hash. That is also the fix for deployments already broken by #591.

Validated on a live model: downgraded to `origin/main`, rewrote the peer record to the old shape, then refreshed to this branch.

```
peer record before : {"client_id": "07ce4967-..."}
peer record after  : {"client_id": "07ce4967-...", "config_hash": "c48d5b5e..."}
hooks after upgrade: upgrade-charm, config-changed, start, hydra-pebble-ready, hydra-relation-changed x3
hydra calls        : 1 update client (targeting 07ce4967-...), 0 create, 0 delete
juju secret        : revision 4 -> 4, value unchanged
```

The client id is preserved, no credentials are republished, and the requirer's pre-upgrade secret still authenticates against the post-upgrade client (`invalid_grant`, not `invalid_client`), with the full OIDC flow returning 302. Two further holistic passes issued zero Hydra calls, so it settles immediately.

## Notes

- `charmcraft pack` from a repo root containing a local `venv/` fails on a parts collision. Pre-existing; CI's clean checkout builds fine.
- A credential publish that keeps failing leaks one Hydra client per reconcile pass. De-duplicating would mean listing every client and filtering on `metadata.integration-id` on every pass — a deliberate non-goal; the failure is logged throughout.
- `LIBPATCH` is bumped to 13; publishing to Charmhub can happen separately, since `lib/` is bundled at build time.
